### PR TITLE
Improvements to popup boxes

### DIFF
--- a/main.js
+++ b/main.js
@@ -1812,6 +1812,11 @@ function gameTimeout() {
 
 setTimeout(gameTimeout(), (1000 / game.settings.speed));
 
-
+document.addEventListener('keydown', function(e) {
+	if (e.keyCode == 27) { // ESC
+		// cancel the current dialog box
+		cancelTooltip();
+	}
+}, true);
 
 document.getElementById("versionNumber").innerHTML = game.global.version;

--- a/updates.js
+++ b/updates.js
@@ -21,7 +21,7 @@
 function tooltip(what, isItIn, event, textString) {
 	if (game.global.lockTooltip) return;
 	var elem = document.getElementById("tooltipDiv");
-	var focusElemId = null;
+	var ondisplay = null; // if non-null, called after the tooltip is displayed
 	if (what == "hide"){
 		elem.style.display = "none";
 		return;
@@ -129,7 +129,13 @@ function tooltip(what, isItIn, event, textString) {
 		game.global.lockTooltip = true;
 		elem.style.left = "32.5%";
 		elem.style.top = "25%";
-		focusElemId = "customNumberBox";
+		ondisplay = function() {
+			var box = document.getElementById("customNumberBox");
+			// Chrome chokes on setSelectionRange on a number box; fall back to select()
+			try { box.setSelectionRange(0, box.value.length); } 
+			catch (e) { box.select(); }
+			box.focus();
+		};
 	}
 	if (what == "Export"){
 		tooltipText = "This is your save string. There are many like it but this one is yours. Save this save somewhere safe so you can save time next time. <br/><br/><textarea style='width: 100%' rows='5'>" + save(true) + "</textarea>";
@@ -216,8 +222,8 @@ function tooltip(what, isItIn, event, textString) {
 	document.getElementById("tipText").innerHTML = tooltipText;
 	document.getElementById("tipCost").innerHTML = costText;
 	elem.style.display = "block";
-	if (focusElemId != null)
-		document.getElementById(focusElemId).focus();
+	if (ondisplay != null)
+		ondisplay();
 }
 
 function unlockTooltip(){

--- a/updates.js
+++ b/updates.js
@@ -21,6 +21,7 @@
 function tooltip(what, isItIn, event, textString) {
 	if (game.global.lockTooltip) return;
 	var elem = document.getElementById("tooltipDiv");
+	var focusElemId = null;
 	if (what == "hide"){
 		elem.style.display = "none";
 		return;
@@ -128,6 +129,7 @@ function tooltip(what, isItIn, event, textString) {
 		game.global.lockTooltip = true;
 		elem.style.left = "32.5%";
 		elem.style.top = "25%";
+		focusElemId = "customNumberBox";
 	}
 	if (what == "Export"){
 		tooltipText = "This is your save string. There are many like it but this one is yours. Save this save somewhere safe so you can save time next time. <br/><br/><textarea style='width: 100%' rows='5'>" + save(true) + "</textarea>";
@@ -212,8 +214,10 @@ function tooltip(what, isItIn, event, textString) {
 	}
 	document.getElementById("tipTitle").innerHTML = what;
 	document.getElementById("tipText").innerHTML = tooltipText;
-	document.getElementById("tipCost").innerHTML = costText;	
+	document.getElementById("tipCost").innerHTML = costText;
 	elem.style.display = "block";
+	if (focusElemId != null)
+		document.getElementById(focusElemId).focus();
 }
 
 function unlockTooltip(){

--- a/updates.js
+++ b/updates.js
@@ -91,7 +91,7 @@ function tooltip(what, isItIn, event, textString) {
 	if (what == "Trustworthy Trimps"){
 		tooltipText = textString;
 		game.global.lockTooltip = true;
-		costText = "<div class='maxCenter'><div class='btn btn-info' onclick='unlockTooltip(); tooltip(\"hide\")'>Sweet, thanks.</div></div>";
+		costText = "<div class='maxCenter'><div class='btn btn-info' onclick='cancelTooltip()'>Sweet, thanks.</div></div>";
 		elem.style.left = "32.5%";
 		elem.style.top = "25%";
 	}
@@ -105,7 +105,7 @@ function tooltip(what, isItIn, event, textString) {
 	}
 	if (what == "Reset"){
 		tooltipText = "Are you sure you want to reset? This will really actually reset your game. You won't get anything cool. It will be gone.";
-		costText="<div class='maxCenter'><div class='btn btn-info' onclick='resetGame();unlockTooltip();tooltip(\"hide\")'>Reset</div><div class='btn btn-info' onclick='unlockTooltip(); tooltip(\"hide\")'>Cancel</div></div>";
+		costText="<div class='maxCenter'><div class='btn btn-info' onclick='resetGame();unlockTooltip();tooltip(\"hide\")'>Reset</div><div class='btn btn-info' onclick='cancelTooltip()'>Cancel</div></div>";
 		game.global.lockTooltip = true;
 		elem.style.left = "32.5%";
 		elem.style.top = "25%";
@@ -125,7 +125,7 @@ function tooltip(what, isItIn, event, textString) {
 	}
 	if (what == "Custom"){
 		tooltipText = "Type a number below to purchase a specific amount. (Max is 15000)<br/><br/><input type='number' id='customNumberBox' style='width: 50%' value='" + game.global.lastCustomAmt + "'></input>"
-		costText = "<div class='maxCenter'><div class='btn btn-info' onclick='numTab(5)'>Apply</div><div class='btn btn-info' onclick='unlockTooltip(); tooltip(\"hide\")'>Cancel</div></div>";
+		costText = "<div class='maxCenter'><div class='btn btn-info' onclick='numTab(5)'>Apply</div><div class='btn btn-info' onclick='cancelTooltip()'>Cancel</div></div>";
 		game.global.lockTooltip = true;
 		elem.style.left = "32.5%";
 		elem.style.top = "25%";
@@ -139,14 +139,14 @@ function tooltip(what, isItIn, event, textString) {
 	}
 	if (what == "Export"){
 		tooltipText = "This is your save string. There are many like it but this one is yours. Save this save somewhere safe so you can save time next time. <br/><br/><textarea style='width: 100%' rows='5'>" + save(true) + "</textarea>";
-		costText = "<div class='maxCenter'><div class='btn btn-info' onclick='unlockTooltip(); tooltip(\"hide\")'>Got it</div></div>";
+		costText = "<div class='maxCenter'><div class='btn btn-info' onclick='cancelTooltip()'>Got it</div></div>";
 		game.global.lockTooltip = true;
 		elem.style.left = "32.5%";
 		elem.style.top = "25%";
 	}
 	if (what == "Import"){
 		tooltipText = "Import your save string! It'll be fun, I promise.<br/><br/><textarea id='importBox' style='width: 100%' rows='5'></textarea>";
-		costText="<div class='maxCenter'><div class='btn btn-info' onclick='load(true); unlockTooltip(); tooltip(\"hide\")'>Import</div><div class='btn btn-info' onclick='unlockTooltip(); tooltip(\"hide\")'>Cancel</div></div>";
+		costText="<div class='maxCenter'><div class='btn btn-info' onclick='load(true); cancelTooltip()'>Import</div><div class='btn btn-info' onclick='cancelTooltip()'>Cancel</div></div>";
 		game.global.lockTooltip = true;
 		elem.style.left = "32.5%";
 		elem.style.top = "25%";
@@ -224,6 +224,12 @@ function tooltip(what, isItIn, event, textString) {
 	elem.style.display = "block";
 	if (ondisplay != null)
 		ondisplay();
+}
+
+// Correct function to call to cancel the current tooltip
+function cancelTooltip(){
+	unlockTooltip();
+	tooltip("hide");
 }
 
 function unlockTooltip(){


### PR DESCRIPTION
I have made several improvements to the "tooltip" functionality:
* Fixed HTML error in Custom Quantity popup
* Custom Quantity popup starts with the keyboard focus in the right spot
* Custom Quantity popup starts with text pre-selected so it can easily be overwritten
* ESC key now closes tooltips and popups (Import, Export, Custom Quantity)