### PR TITLE
`prettify` fixes

### DIFF
--- a/config.js
+++ b/config.js
@@ -1622,7 +1622,7 @@ var toReturn = {
 			finished: 0,
 			title: "Trimp Damage",
 			description: function (number) {
-				return "Reach " + prettify(this.breakpoints[number], null, true) + " displayed damage";
+				return "Reach " + prettify(this.breakpoints[number]) + " displayed damage";
 			},
 			progress: function () {				
 				if (this.breakpoints.length > this.finished) return prettify(this.highest) + " / " + prettify(this.breakpoints[this.finished]);

--- a/updates.js
+++ b/updates.js
@@ -1428,6 +1428,7 @@ function prettify(number) {
 	if (!isFinite(number)) return "<span class='icomoon icon-infinity'></span>";
 	if (number >= 1000 && number < 10000) return Math.floor(number);
 	if (number === 0) return prettifySub(0);
+	if (number < 0) return "-" + prettify(-number);
 
 	var base = Math.floor(Math.log(number)/Math.log(1000));
 	if (base <= 0) return prettifySub(number);

--- a/updates.js
+++ b/updates.js
@@ -1440,13 +1440,10 @@ function prettify(number) {
 		'Tv', 'Qav', 'Qiv', 'Sxv', 'Spv', 'Ov', 'Nv', 'Tt'
 	];
 	var suffix;
-	if ((base <= suffices.length && base > 0) && game.options.menu.standardNotation.enabled)
-	{
-		if (game.options.menu.standardNotation.enabled == 2) 
-			suffix = "e" + ((base) * 3);
-		else
-			suffix = suffices[base-1];
-	}
+	if (game.options.menu.standardNotation.enabled == 2)
+		suffix = "e" + ((base) * 3);
+	else if (game.options.menu.standardNotation.enabled && base <= suffices.length)
+		suffix = suffices[base-1];
 	else
 	{
 		var exponent = parseFloat(numberTmp).toExponential(2);

--- a/updates.js
+++ b/updates.js
@@ -295,7 +295,7 @@ function tooltip(what, isItIn, event, textString, attachFunction, numCheck, rena
 		customUp = (textString) ? 2 : 1;
 		tooltipText = "Type a number below to purchase a specific amount. You can also use shorthand such as 2e5 and 200k to select that large number, or fractions such as 1/2 and 50% to select that fraction of your available workspaces."
 		if (textString) tooltipText += " <b>Max of 1,000 for most perks</b>";
-		tooltipText += "<br/><br/><input id='customNumberBox' style='width: 50%' value='" + ((!isNaN(game.global.lastCustomExact)) ? prettify(game.global.lastCustomExact, true) : game.global.lastCustomExact) + "'></input>";
+		tooltipText += "<br/><br/><input id='customNumberBox' style='width: 50%' value='" + ((!isNaN(game.global.lastCustomExact)) ? prettify(game.global.lastCustomExact) : game.global.lastCustomExact) + "'></input>";
 		costText = "<div class='maxCenter'><div id='confirmTooltipBtn' class='btn btn-info' onclick='numTab(5, " + textString + ")'>Apply</div><div class='btn btn-info' onclick='cancelTooltip()'>Cancel</div></div>";
 		game.global.lockTooltip = true;
 		elem.style.left = "33.75%";
@@ -1422,7 +1422,7 @@ function swapNotation(updateOnly){
 	if (game.global.fighting) updateAllBattleNumbers();
 }
 
-function prettify(number, noSup) {
+function prettify(number) {
 	var numberTmp = number;
 	number = Math.round(number * 1000000) / 1000000;
 	if (!isFinite(number)) return "<span class='icomoon icon-infinity'></span>";

--- a/updates.js
+++ b/updates.js
@@ -1427,12 +1427,10 @@ function prettify(number) {
 	number = Math.round(number * 1000000) / 1000000;
 	if (!isFinite(number)) return "<span class='icomoon icon-infinity'></span>";
 	if (number >= 1000 && number < 10000) return Math.floor(number);
-	if(number === 0)
-	{
-		return prettifySub(0);
-	}
+	if (number === 0) return prettifySub(0);
+
 	var base = Math.floor(Math.log(number)/Math.log(1000));
-	if (base <= 0) return prettifySub(number);	
+	if (base <= 0) return prettifySub(number);
 	number /= Math.pow(1000, base);
 	
 	var suffices = [


### PR DESCRIPTION
This branch fixes a few edge cases with the `prettify` function. In particular, it fixes a [bug that was reported on reddit](https://www.reddit.com/r/Trimps/comments/53agvq/bugengineer_notation_not_working_after_e100/): engineering notation doesn’t work for very large numbers (≥ 1e96).

It also makes some formatting fixes, and adds the handling of negative numbers, in case it is ever needed.