### PR TITLE
AutoPants fix

### DIFF
--- a/main.js
+++ b/main.js
@@ -7344,6 +7344,10 @@ function autoPrestiges(equipmentAvailable) {
 		if (cheapestWeapon[0])	autoBuyUpgrade(cheapestWeapon[0]);
 		return;
 	}
+	if (game.global.autoPrestiges == 4){ // Pants only
+		if (equipmentAvailable.armor.indexOf("Pantastic") != -1) autoBuyUpgrade("Pantastic");
+		return;
+	}
 	var cheapestArmor = getCheapestPrestigeUpgrade(equipmentAvailable.armor);
 	if (!cheapestWeapon[0]) {
 		if (cheapestArmor[0])
@@ -7359,10 +7363,6 @@ function autoPrestiges(equipmentAvailable) {
 		toBuy = (cheapestWeapon[1] < cheapestArmor[1]) ? cheapestWeapon[0] : cheapestArmor[0];
 	else if (game.global.autoPrestiges == 3) //Weapons First
 		toBuy = (cheapestWeapon[1] < (cheapestArmor[1] * 20)) ? cheapestWeapon[0] : cheapestArmor[0];
-	else if (game.global.autoPrestiges == 4){
-		if (equipmentAvailable.armor.indexOf("Pantastic") != -1) toBuy = "Pantastic";
-		else return;
-	}
 	if (!toBuy) return;
 	var bought = autoBuyUpgrade(toBuy);
 	if (toBuy == "Supershield" && !bought && game.global.autoPrestiges == 1) autoBuyUpgrade(cheapestWeapon[0]);


### PR DESCRIPTION
The secret AutoPrestige setting, PANTS ONLY, would actually buy any prestige
as long as all available prestiges belonged to the same category (all armors
or all weapons).

This was due to some logic shared with Weapons First / Prestige All. The fix
was to move the PANTS ONLY check earlier, in line with what was done for
Weapons Only.