### PR TITLE
Fix inconsistencies in prettifySub (fixes #37)

### DIFF
--- a/updates.js
+++ b/updates.js
@@ -1550,7 +1550,6 @@ function swapNotation(updateOnly){
 
 function prettify(number) {
 	var numberTmp = number;
-	number = Math.round(number * 1000000) / 1000000;
 	if (!isFinite(number)) return "<span class='icomoon icon-infinity'></span>";
 	if (number >= 1000 && number < 10000) return Math.floor(number);
 	if (number === 0) return prettifySub(0);
@@ -1624,12 +1623,11 @@ function romanNumeral(number){
 }
 
 function prettifySub(number){
-	number = parseFloat(number.toFixed(3));
-	if (number >= 1000) number = 999;
-	number = number.toString();
-	var hasDecimal = number.split('.');
-	if (typeof hasDecimal[1] === 'undefined' || hasDecimal[0].length >= 3) return number.substring(0, 3);
-	return number.substring(0, 4);	
+	var floor = Math.floor(number);
+	if (number === floor) // number is an integer, just show it as-is
+		return number;
+	var precision = 3 - floor.toString().length; // use the right number of digits
+	return number.toFixed(3 - floor.toString().length);
 }
 
 function resetGame(keepPortal) {
@@ -3218,22 +3216,3 @@ if (elem == null) {
   	className = className[0] + newClass;
   elem.className = className;
 }
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-


### PR DESCRIPTION
Some results were incorrectly rounded (1699499 showed as 1.69M, even though 1.70M is more accurate), and significant digits were sometimes chopped off (showing 1.7M instead of 1.70M under some circumstances).

Here are the results of my tests following this fix:

```
16949: 16.9K
16950: 16.9K
16951: 17.0K
16999: 17.0K
17000: 17K
17001: 17.0K
17049: 17.0K
17050: 17.1K
17051: 17.1K

169499: 169K
169500: 170K
169501: 170K
169949: 170K
169950: 170K
169999: 170K
170000: 170K
170001: 170K
170050: 170K
170051: 170K
170499: 170K
170500: 171K
170501: 171K

1694999: 1.69M
1695000: 1.70M
1695001: 1.70M
1699499: 1.70M
1699500: 1.70M
1699999: 1.70M
1700000: 1.70M
1700001: 1.70M
1700500: 1.70M
1700501: 1.70M
1704999: 1.70M
1705000: 1.71M
1705001: 1.71M
```
