### PR TITLE
HTML validation (fixes #38)

### DIFF
--- a/index.html
+++ b/index.html
@@ -697,7 +697,6 @@
 										<option value="Sea">Sea</option>
 										<option value="Depths">Depths</option>
 									</select>
-									<div id="difficultyAdvMapsText"></div>
 								</div>
 							</div>
 							<div id="heirRare" style="display: none">

--- a/indexKong.html
+++ b/indexKong.html
@@ -62,7 +62,7 @@ var kongregate = parent.kongregateAPI.getAPI();
 						You have <span id="bonesOwned">0</span> bones
 					</div>
 					<div id="getBonesBtn" class="boneBtn successColor pointer noselect" style="width: 33vw; display: inline-block" onclick="showPurchaseBones()">
-						<span class="kredSpan"><img class="kredImg" src="imgs/kred_single.png"></img></span> Get some more bones</span>						
+						<span class="kredSpan"><img class="kredImg" src="imgs/kred_single.png" /></span> Get some more bones</span>
 					</div>
 					<br/>
 					<span id="bonesFrom">You Can Also Earn Bones In Game By Killing Skeletimps</span>
@@ -224,33 +224,33 @@ var kongregate = parent.kongregateAPI.getAPI();
 							&nbsp;
 						</td>
 						<td>
-							10 <span class="kredSpan"><img class="kredImg" src="imgs/kred_single.png"></img></span>
+							10 <span class="kredSpan"><img class="kredImg" src="imgs/kred_single.png" /></span>
 						</td>
 					</tr>
 					<tr class="pointer noSelect" onclick="kredPurchase('42.bones')">
 						<td>42 Bones</td>
 						<td>(Includes +2 bones!)</td>
-						<td>20 <span class="kredSpan"><img class="kredImg" src="imgs/kred_single.png"></img></span></td>
+						<td>20 <span class="kredSpan"><img class="kredImg" src="imgs/kred_single.png" /></span></td>
 					</tr>
 					<tr class="pointer noSelect" onclick="kredPurchase('110.bones')">
 						<td>110 Bones</td>
 						<td>(Includes +10 bones!)</td>
-						<td>50 <span class="kredSpan"><img class="kredImg" src="imgs/kred_single.png"></img></span></td>
+						<td>50 <span class="kredSpan"><img class="kredImg" src="imgs/kred_single.png" /></span></td>
 					</tr>
 					<tr class="pointer noSelect" onclick="kredPurchase('230.bones')">
 						<td>230 Bones</td>
 						<td>(Includes +30 bones!)</td>
-						<td>100 <span class="kredSpan"><img class="kredImg" src="imgs/kred_single.png"></img></span></td>
+						<td>100 <span class="kredSpan"><img class="kredImg" src="imgs/kred_single.png" /></span></td>
 					</tr>
 					<tr class="pointer noSelect" onclick="kredPurchase('480.bones')">
 						<td>480 Bones</td>
 						<td>(Includes +80 bones!)</td>
-						<td>200 <span class="kredSpan"><img class="kredImg" src="imgs/kred_single.png"></img></span></td>
+						<td>200 <span class="kredSpan"><img class="kredImg" src="imgs/kred_single.png" /></span></td>
 					</tr>
 					<tr id="bundleRow" class="pointer noSelect" onclick="startBundling()">
 						<td>4 Exotic Imp-orts of your choice<br/>AND 100 bones</td>
 						<td>(Includes +100 bones!)</td>
-						<td>100 <span class="kredSpan"><img class="kredImg" src="imgs/kred_single.png"></img></span></td>
+						<td>100 <span class="kredSpan"><img class="kredImg" src="imgs/kred_single.png" /></span></td>
 					</tr>
 				</tbody>
 			</table>
@@ -800,7 +800,6 @@ var kongregate = parent.kongregateAPI.getAPI();
 										<option value="Sea">Sea</option>
 										<option value="Depths">Depths</option>
 									</select>
-									<div id="difficultyAdvMapsText"></div>
 								</div>
 							</div>
 							<div id="heirRare" style="display: none">

--- a/updates.js
+++ b/updates.js
@@ -314,7 +314,7 @@ function tooltip(what, isItIn, event, textString, attachFunction, numCheck, rena
 		customUp = (textString) ? 2 : 1;
 		tooltipText = "Type a number below to purchase a specific amount. You can also use shorthand such as 2e5 and 200k to select that large number, or fractions such as 1/2 and 50% to select that fraction of your available workspaces."
 		if (textString) tooltipText += " <b>Max of 1,000 for most perks</b>";
-		tooltipText += "<br/><br/><input id='customNumberBox' style='width: 50%' value='" + ((!isNaN(game.global.lastCustomExact)) ? prettify(game.global.lastCustomExact) : game.global.lastCustomExact) + "'></input>";
+		tooltipText += "<br/><br/><input id='customNumberBox' style='width: 50%' value='" + ((!isNaN(game.global.lastCustomExact)) ? prettify(game.global.lastCustomExact) : game.global.lastCustomExact) + "' />";
 		costText = "<div class='maxCenter'><div id='confirmTooltipBtn' class='btn btn-info' onclick='numTab(5, " + textString + ")'>Apply</div><div class='btn btn-info' onclick='cancelTooltip()'>Cancel</div></div>";
 		game.global.lockTooltip = true;
 		elem.style.left = "33.75%";


### PR DESCRIPTION
The game’s HTML contained some constructs that are invalid according to the
spec. The fixes are pretty straightforward.

This second difficultyAdvMapsText div under the Biome section really looked like
a copy-paste mistake, so I deleted it outright instead of simply changing the
ID. It didn’t cause any problems in my tests.