### PR TITLE
Automatically select newly created maps

### DIFF
--- a/main.js
+++ b/main.js
@@ -2726,6 +2726,8 @@ function createMap(newLevel, nameOverride, locationOverride, lootOverride, sizeO
 	game.global.mapsOwnedArray.push(newMap);
     if (!messageOverride) message("You just made " + mapName[0] + "!", "Loot", "th-large", null, 'secondary');
     unlockMap(game.global.mapsOwnedArray.length - 1);
+	if (game.global.currentMapId === "")
+		selectMap(newMap.id);
 }
 
 function checkVoidMap() {


### PR DESCRIPTION
In my experience, 100% of the time where I’m creating a new map, it’s because I want to run it. So there’s really no reason not to select it automatically. I’ve seen a lot of agreement with this idea on Kong chat.

Note that to avoid any problems, we only select new maps when the player is not currently running a map.