### PR TITLE
Prevent selecting empty map cells

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -959,6 +959,12 @@ overflow-x: hidden;
     text-align: left;
 	list-style: none;
 	padding-left: 0;
+	cursor: default;
+	-webkit-user-select: none;
+	-moz-user-select: none;
+	-ms-user-select: none;
+	-o-user-select: none;
+	user-select: none;
 }
 
 .battleRow{


### PR DESCRIPTION
Each empty map cell contains an unbreakable space. It’s pretty common to
accidentally select those spaces, which looks ugly. This commit disables
text selection on the map. It also forces the default cursor for the map
(the cursor would otherwise flicker from default to text caret when over
an unbreakable space).

Example of the old behavior:
![user-select](https://cloud.githubusercontent.com/assets/3199732/19040939/785569b2-8986-11e6-86e2-30f3d01fd732.png)
