### PR TITLE
Make some daily rules clearer

### DIFF
--- a/main.js
+++ b/main.js
@@ -5367,7 +5367,7 @@ var dailyModifiers = {
         },
         maxDamage: {
             description: function (str) {
-                return "Trimp max damage increased by " + prettify(this.getMult(str) * 100) + "%.";
+                return "Trimp max damage increased by " + prettify(this.getMult(str) * 100) + "% (additive).";
             },
             getMult: function (str) {
                 return str;

--- a/updates.js
+++ b/updates.js
@@ -1034,7 +1034,7 @@ function getBattleStatBd(what) {
 					if (typeof game.global.dailyChallenge.maxDamage !== 'undefined'){
 						var addMax = dailyModifiers.maxDamage.getMult(game.global.dailyChallenge.maxDamage.strength);
 						maxFluct += addMax;
-						textString += "<tr><td class='bdTitle'>Prodigal (Daily)</td><td class='bdPercentSm'>+" + prettify(addMax * 100) + "% Max</td><td></td><td></td><td class='bdNumberSm'></td><td>+" + prettify(minFluct * 100) + "%</td><td>+" + prettify(maxFluct * 100) + "%</td></tr>";
+						textString += "<tr><td class='bdTitle'>Prodigal (Daily)</td><td class='bdPercentSm'>+" + prettify(addMax * 100) + "% Max</td><td></td><td></td><td class='bdNumberSm'></td><td>-" + prettify(minFluct * 100) + "%</td><td>+" + prettify(maxFluct * 100) + "%</td></tr>";
 					}
 			}
 		}


### PR DESCRIPTION
This fixes two minor issues with daily challenge rules:

* From the description of Prodigal, it’s unclear whether the bonus is additive
  (120% + 550% = 670%) or multiplicative (120% * (1 + 5.5) = 780%). Adding
  " (additive)" to the description.

* The Minimalist challenge shows up as "+75% Min" in the damage breakdown, when
  it’s actually -75% Min.