### PR TITLE
Fix for “Gym X2.00”

### DIFF
--- a/updates.js
+++ b/updates.js
@@ -1624,12 +1624,13 @@ function romanNumeral(number){
 }
 
 function prettifySub(number){
+	number = parseFloat(number);
 	var floor = Math.floor(number);
 	if (number === floor) // number is an integer, just show it as-is
 		return number;
 	var precision = 3 - floor.toString().length; // use the right number of digits
 
-	return parseFloat(number).toFixed(3 - floor.toString().length);
+	return number.toFixed(3 - floor.toString().length);
 }
 
 function resetGame(keepPortal) {


### PR DESCRIPTION
Following the previous prettify patch, multiple buildings in queue started showing as “Gym X2.00”. This is because I missed the fact that `number` could actually be a string, and my check for integers uses `===`. When @Trimps added the `parseFloat`, it was added *after* that check, which is too late.

This patch moves the `parseFloat` earlier in the function, which should cover all cases. I only made a quick test, but at least it *does* fix the “Gym X2.00”.