### PR TITLE
Famine should not reduce gems while offline

### DIFF
--- a/main.js
+++ b/main.js
@@ -1130,7 +1130,7 @@ function checkOfflineProgress(noTip){
 		if (game.global.challengeActive == "Meditate") amt *= 1.25;
 		if (game.global.challengeActive == "Balance") amt *= game.challenges.Balance.getGatherMult();
 		if (game.global.challengeActive == "Daily"){
-			if (typeof game.global.dailyChallenge.famine !== 'undefined' && x < 4){
+			if (typeof game.global.dailyChallenge.famine !== 'undefined' && x < 3){
 				amt *= dailyModifiers.famine.getMult(game.global.dailyChallenge.famine.strength);
 			}
 			if (typeof game.global.dailyChallenge.dedication !== 'undefined'){


### PR DESCRIPTION
The code added in 2be31f1 to handle Famine while offline uses `x < 4`, which
causes it to reduce the first four resources: food, wood, metal, and gems.
However, Famine is supposed to only reduce food, wood, and metal. Thus, this
condition should read `x < 3` instead.