### PR TITLE
prettify: show 999500 as 1.00M, not 1000K

### DIFF
--- a/updates.js
+++ b/updates.js
@@ -1570,6 +1570,11 @@ function prettify(number) {
 	var base = Math.floor(Math.log(number)/Math.log(1000));
 	if (base <= 0) return prettifySub(number);
 	number /= Math.pow(1000, base);
+	if (number >= 999.5) {
+		// 999.5 rounds to 1000 and we don’t want to show “1000K” or such
+		number /= 1000;
+		++base;
+	}
 	
 	var suffices = [
 		'K', 'M', 'B', 'T', 'Qa', 'Qi', 'Sx', 'Sp', 'Oc', 'No', 'Dc', 'Ud',


### PR DESCRIPTION
The code from ab2c2f6 causes some numbers to be displayed as the odd-looking “1000**Unit**”. This commit changes that to the standard “1.00**Unit**”.