### PR TITLE
Don’t signal turkimp buff when it’s buffing 0 workers

### DIFF
--- a/main.js
+++ b/main.js
@@ -1747,7 +1747,8 @@ function setGather(what, updateOnly) {
     var colorOn = "workColorOn";
 	var btnText = "";
 	var collectBtn;
-	if (game.global.turkimpTimer > 0 && (what == "food" || what == "wood" || what == "metal")){
+	var job = what == "food" ? "Farmer" : what == "wood" ? "Lumberjack" : what == "metal" ? "Miner" : false;
+	if (game.global.turkimpTimer > 0 && job && game.jobs[job].owned > 0) {
 		colorOn = "workColorTurkimp";
 		btnText = "<span class='icomoon icon-spoon-knife'></span>";
 	}
@@ -2189,6 +2190,7 @@ function buyJob(what, confirmed, noTip) {
 		game.stats.trimpsFired.value += purchaseAmt;
 		if (game.jobs[what].owned < 0) game.jobs[what].owned = 0;
 		if (game.resources.trimps.employed < 0) game.resources.trimps.employed = 0;
+		if (game.global.playerGathering) setGather(game.global.playerGathering);
 		return;
 	}
 	var workspaces = Math.ceil(game.resources.trimps.realMax() / 2) - game.resources.trimps.employed;
@@ -2197,6 +2199,7 @@ function buyJob(what, confirmed, noTip) {
 	var added = canAffordJob(what, true, workspaces);
 	game.jobs[what].owned += added;
 	game.resources.trimps.employed += added;
+	if (game.global.playerGathering) setGather(game.global.playerGathering);
 	if (!noTip) tooltip(what, "jobs", "update");
 }
 


### PR DESCRIPTION
When gathering food, wood or metal with a turkimp buff, the gathering icon
changes color and gains a `spoon-knife` icon, signalling that the workers
assigned to this resource are buffed by sharing food.

However, this can be misleading. When no workers are assigned to the resource in
question, the buff has very little effect (+50% of 0 production is still 0; the
+16.9% loot still applies, but is usually minor).

This commit adds a check so that the color and icon are only applied if workers
are assigned to the resource gathered by the player. This is also updated when
hiring or firing trimps.

Since I switch between 1:0:0 and 0:0:1 worker repartitions depending on what I need, I often end up with the player gathering the wrong resource, which is annoying. This small change would help with noticing that. Players using more traditionnal worker repartitions where each resource always has at least one worker might never notice the change.