### PR TITLE
4.0 related fixes

### DIFF
--- a/config.js
+++ b/config.js
@@ -835,7 +835,7 @@ var toReturn = {
 		},
 		blacksmith2: {
 			get description () {
-				return "Each cleared zone through Z" + Math.floor((game.global.highestLevelCleared + 1) / 1.33) + " (75% of your highest zone reached) will drop all available equipment prestiges from maps.";
+				return "Each cleared zone through Z" + Math.floor((game.global.highestLevelCleared + 1) * 0.75) + " (75% of your highest zone reached) will drop all available equipment prestiges from maps.";
 			},
 			name: "Blacksmithery II",
 			tier: 5,
@@ -1751,7 +1751,7 @@ var toReturn = {
 			owned: false
 		}
 	},
-	//Total 1335.2% after adding daily bonus helium
+	//Total 1635.2% after adding Z230-Z300 zone progress
 	tierValues: [0, 0.3, 1, 2.5, 5, 10, 20, 40],
 	colorsList: ["white", "#155515", "#151565", "#551555", "#954515", "#651515", "#951545", "#35a5a5"], //handwritten hex colors make the best hex colors
 	achievements: {
@@ -2963,8 +2963,6 @@ var toReturn = {
 					percentage = (game.global.challengeActive == "Corrupted") ? 0.075 : 0.15;
 					percentage *= mutations.Corruption.cellCount() * 2;
 					percentage += 2;
-					console.log(percentage);
-					console.log(amt);
 				}
 				amt = rewardResource("helium", amt, level, false, percentage);
 				var msg = "Cthulimp and the map it came from crumble into the darkness. You find yourself instantly teleported to ";

--- a/main.js
+++ b/main.js
@@ -3720,13 +3720,6 @@ var mutations = {
 		},
 		getTrimpDecayMult: function (world){
 			return 0.8;
-			if (!world) world = game.global.world;
-			var decay = (1 - ((1 / ((world - mutations.Magma.start()) + 100)) * 100));
-			decay -= 0.2;
-			if (decay < 0) decay = 0;
-			decay += 0.2;
-			decay = 1 - decay;
-			return decay;
 		},
         getEligibleOrigin: function(currentArray) {
 			if(game.global.world % 5 === 0 && this.targetCells === this.singlePathMaxSize) {
@@ -5892,11 +5885,8 @@ function getNextTalentCost(){
 }
 
 function getTotalTalentCost(){
-	var cost = 0;
-	for (var x = 0; x < Object.keys(game.talents).length; x++){
-		cost += Math.floor(10 * Math.pow(3, x));
-	}
-	return cost;
+	var count = Object.keys(game.talents).length;
+	return 10 * (Math.pow(3, count) - 1) / (3 - 1);
 }
 
 function nextWorld() {
@@ -5966,7 +5956,7 @@ function nextWorld() {
 	if (game.talents.blacksmith.purchased){
 		if (game.global.world <= Math.floor((game.global.highestLevelCleared + 1) / 2))
 			dropPrestiges();
-		else if (game.talents.blacksmith2.purchased && game.global.world <= Math.floor((game.global.highestLevelCleared + 1) / 1.33))
+		else if (game.talents.blacksmith2.purchased && game.global.world <= Math.floor((game.global.highestLevelCleared + 1) * 0.75))
 			dropPrestiges();
 	}
 	if (game.talents.bionic.purchased){

--- a/updates.js
+++ b/updates.js
@@ -991,7 +991,8 @@ function getTrimpPs() {
 	if (game.jobs.Geneticist.owned > 0) {
 		var mult = Math.pow(.98, game.jobs.Geneticist.owned);
 		currentCalc *= mult;
-		textString += "<tr style='color: red'><td class='bdTitle'>Geneticist</td><td class='bdPercent'>X  " + mult.toFixed(6) + "</td><td class='bdNumber'>" + prettify(currentCalc) + "</td></tr>"
+		var display = (mult > 0.0001) ? mult.toFixed(4) : mult.toExponential(3);
+		textString += "<tr style='color: red'><td class='bdTitle'>Geneticist</td><td class='bdPercent'>X  " + display + "</td><td class='bdNumber'>" + prettify(currentCalc) + "</td></tr>";
 	}
 	//Add quick trimps
 	if (game.unlocks.quickTrimps){


### PR DESCRIPTION
* Remove some stray `console.log` calls

* Fix the “total achievement bonus” comment

* Remove dead code in the `getTrimpDecayMult()` function

* Change the Blacksmithery II formula to match its description: `(highestLevelCleared / 1.33)` is about 75.2% of HZE, not 75%.

* Remove the loop in `getTotalTalentCost()` (using the formula for the sum of a geometric series)

* Update the display of the geneticist breeding speed debuff to use exponential notation if needed, like it was done for Overheated

Most of these changes have no visible effect on behavior. The new Blacksmithery II produces results that differ by at most one zone form the current formula:

* Users with the following highestLevelCleared values will *gain* one more zone of Blacksmithery: 230, 233, 234, 237, 238, 241, 242, 245, 246, 249, 250, 253, 254, 257, 258, 261, 262, 266, 270, 274, 278, 282, 286, 290, 294, 298, 302, 306, 310, 314, 318, 322, 326, 330, 334, 338, 342, 346, 350, 354, 358, 362, 366, 370, 374, 378, 382, 386, 390, 394.

* Users with the following highestLevelCleared values will *lose* a zone of Blacksmithery: 531, 535, 539, 543, 547, 551, 555, 559, 563, 567, 571, 575, 579, 583, 587, 591, 595, 599.