### PR TITLE
Helium: round before multiplying by the base amount

### DIFF
--- a/main.js
+++ b/main.js
@@ -1667,8 +1667,8 @@ function rewardResource(what, baseAmt, level, checkMapLootScale, givePercentage)
 		}
 		level *= 1.35;
 		if (level < 0) level = 0;
-		amt += Math.round(baseAmt * Math.pow(1.23, Math.sqrt(level)));
-		amt += Math.round(baseAmt * level);
+		amt += baseAmt * Math.round(Math.pow(1.23, Math.sqrt(level)));
+		amt += baseAmt * Math.round(level);
 	}
 	//Scale 20% across the zone, depending on cell number
 	if (what != "helium" && what != "fragments"){


### PR DESCRIPTION
The code was rounding helium gains *after* multiplying by the base amount, which caused small discrepancies, particularly noticeable in the lower zones. See [this bug report on Reddit](https://www.reddit.com/r/Trimps/comments/5eb224/void_map_helium_bug/), and in particular [this comment](https://www.reddit.com/r/Trimps/comments/5eb224/void_map_helium_bug/dacjnda/).