### PR TITLE
addHelium: correctly set global.tempHighHelium

### DIFF
--- a/main.js
+++ b/main.js
@@ -1739,7 +1739,7 @@ function addHelium(amt){
 	if (portalWindowOpen){
 		var heElem = document.getElementById('portalHelium');
 		game.resources.helium.respecMax += amt;
-		game.resources.helium.tempHighHelium += amt;
+		game.global.tempHighHelium += amt;
 		if (heElem != null) heElem.innerHTML = '<span id="portalHeliumOwned">' + prettify(game.resources.helium.respecMax - game.resources.helium.totalSpentTemp) + '</span> Helium';			
 	}
 	checkAchieve("totalHelium");


### PR DESCRIPTION
Fixes a bug that was reported on Reddit: [Portalling with daily activated doesn't set bone portal](https://www.reddit.com/r/Trimps/comments/5gkyje/portalling_with_daily_activated_doesnt_set_bone/).

Also fixes the fact that helium earned on the portal screen doesn’t count toward BP.