### PR TITLE
Show Grindless in red if nurseries were purchased

### DIFF
--- a/updates.js
+++ b/updates.js
@@ -3527,7 +3527,7 @@ function toggleSetting(setting, elem, fromPortal, updateOnly){
 				return (game.global.challengeActive == "Toxicity" && game.challenges.Toxicity.highestStacks <= 400);
 			},
 			f20: function () {
-				return (game.global.challengeActive == "Watch" && !game.challenges.Watch.enteredMap);
+				return (game.global.challengeActive == "Watch" && !game.challenges.Watch.enteredMap && game.buildings.Nursery.purchased == 0);
 			},
 			f21: function () {
 				return (game.global.challengeActive == "Lead" && game.upgrades.Gigastation.done <= 1);


### PR DESCRIPTION
Fixes [a bug reported on Reddit](https://www.reddit.com/r/Trimps/comments/6810qq/grindless_achievement_w_nurseries/).