### PR TITLE
Fix Sci IV giving double prestiges in Mapology with Blacksmithery

### DIFF
--- a/main.js
+++ b/main.js
@@ -5331,7 +5331,7 @@ function dropPrestiges(){
 	for (var x = 0; x < toDrop.length; x++){
 		unlockUpgrade(toDrop[x]);
 		var prestigeUnlock = game.mapUnlocks[toDrop[x]];
-		if (game.global.sLevel >= 4) {
+		if (game.global.sLevel >= 4 && game.global.challengeActive != "Mapology") {
 			unlockUpgrade(toDrop[x]);
 			prestigeUnlock.last += 10;
 		}


### PR DESCRIPTION
The description of Mapology states: "Double prestige from Scientist IV will not
work during this challenge". However, this was only true for prestiges
dropped from maps. Prestiges dropped by Blacksmithery were doubled as usual,
incorrectly ignoring Mapology. This commit fixes that bug.

The issue does not arise on Mapology², since it disables Blacksmithery.