### PR TITLE
Cancel popups when closing the portal screen

### DIFF
--- a/index.html
+++ b/index.html
@@ -954,7 +954,7 @@
 		</div>
 		<div id="portalBtnContainer">
 			<div class="btn btn-primary inPortalBtn" id="activatePortalBtn" onclick="activateClicked()">Activate Portal</div>
-			<div class="btn btn-danger inPortalBtn" id="cancelPortalBtn" onclick="cancelPortal()">Cancel</div>
+			<div class="btn btn-danger inPortalBtn" id="cancelPortalBtn" onclick="cancelTooltip(); cancelPortal()">Cancel</div>
 			<div class="btn btn-warning inPortalBtn" style="display: none" id="respecPortalBtn" onclick="respecPerks()" onmouseover="tooltip('Respec', null, event)" onmouseout="tooltip('hide')"></div>
 			<div class="btn btn-success inPortalBtn" style='display: none' id="swapToCurrentChallengeBtn" onclick="swapToCurrentChallenge()" onmouseover="tooltip('View Current Challenge', 'customText', event, 'Swap the Challenge Selection pane to instead display your current challenge, or vice versa')" onmouseout="tooltip('hide')">View Current Challenge</div>
 		</div>


### PR DESCRIPTION
Now that the portal confirmation is a popup, popups should be dismissed
when closing the portal screen. Otherwise, it’s possible to click “Let’s do it.”
from outside the portal screen, which causes all He earned this run to become
permanently unusable.
    
This bug was reported on Kongregate:
http://www.kongregate.com/forums/11407-bug-reports/topics/750395-helium-gain-bug
http://imgur.com/a/vJWRe.