### PR TITLE
Fade in

### DIFF
--- a/main.js
+++ b/main.js
@@ -8393,7 +8393,6 @@ function affordOneTier(what, whereFrom, take) {
 }
 
 function fadeIn(elem, speed) {
-    var opacity = 0;
     elem = document.getElementById(elem);
     elem.style.opacity = 0;
     if (elem.style.display == "none") elem.style.display = "block";
@@ -8402,13 +8401,16 @@ function fadeIn(elem, speed) {
 		elem.style.opacity = 1;
 		return;
 	}
-    var fadeInt = setInterval(function () {
-        opacity = opacity + 0.01;
+	var total = 100 * speed;
+	var start = Performance.now();
+    var fadeCallback = function (timer) {
+		var opacity = (timer - start) / total;
         elem.style.opacity = opacity;
-        if (opacity >= 1) {
-            clearInterval(fadeInt);
+        if (!(opacity >= 1)) {
+            requestAnimationFrame(fadeCallback);
         }
-    }, speed);
+    };
+	requestAnimationFrame(fadeCallback);
 }
 
 function autoTrap() {

--- a/main.js
+++ b/main.js
@@ -8402,7 +8402,7 @@ function fadeIn(elem, speed) {
 		return;
 	}
 	var total = 100 * speed;
-	var start = Performance.now();
+	var start = performance.now();
     var fadeCallback = function (timer) {
 		var opacity = (timer - start) / total;
         elem.style.opacity = opacity;


### PR DESCRIPTION
It took a while, but here it is. Changing fadeIn to rely on requestAnimationFrame instead of setInterval.
https://www.reddit.com/r/Trimps/comments/665os3/improving_fadein

Alternatively, we could just do elem.animate([{opacity: 0},{opacity: 1}],{duration:100*speed})