### PR TITLE
refactor startfight to be readable

### DIFF
--- a/config.js
+++ b/config.js
@@ -16,7 +16,7 @@
 		author's website, you can find a copy at
 		<trimps.github.io/license.txt>). If not, see
 		<http://www.gnu.org/licenses/>. */
-		 
+
 //Spoilers ahead, proceed with caution
 function newGame () {
 var toReturn = {
@@ -69,7 +69,7 @@ var toReturn = {
 		buyAmt: 1,
 		numTab: 1,
 		spreadsheetMode: false,
-		lockTooltip: false,	
+		lockTooltip: false,
 		portalActive: false,
 		mapsUnlocked: false,
 		lastOnline: 0,
@@ -269,10 +269,10 @@ var toReturn = {
 			}
 			else if (world < 60)
 				amt = (amt * 0.375) + ((amt * 0.7) * (level / 100));
-			else{ 
+			else{
 				amt = (amt * 0.4) + ((amt * 0.9) * (level / 100));
 				amt *= Math.pow(1.15, world - 59);
-			}	
+			}
 			if (world < 60) amt *= 0.85;
 			if (world > 6 && game.global.mapsActive) amt *= 1.1;
 			if (!ignoreImpStat)
@@ -295,7 +295,7 @@ var toReturn = {
 				amt = (amt * 0.5) + ((amt * 0.8) * (level / 100));
 				amt *= Math.pow(1.1, world - 59);
 			}
-			if (world < 60) amt *= 0.75;		
+			if (world < 60) amt *= 0.75;
 			if (world > 5 && game.global.mapsActive) amt *= 1.1;
 			if (!ignoreImpStat)
 				amt *= game.badGuys[name].health;
@@ -318,7 +318,7 @@ var toReturn = {
 			formatModifier: function (number){
 				return prettify(number * 100);
 			},
-			color: "#33bb33", 
+			color: "#33bb33",
 			currentDebuffPower: 0,
 			level: 1,
 			retainLevel: 0,
@@ -537,17 +537,17 @@ var toReturn = {
 						return;
 					}
 					if (this.enabled == 0) {
-						document.getElementById("innerWrapper").style.backgroundColor = "black";	
+						document.getElementById("innerWrapper").style.backgroundColor = "black";
 						link = document.getElementById("darkTheme");
 						if (!link) return;
 						link.disabled = true;
 						document.head.removeChild(link);
 						return;
 					}
-					document.getElementById("innerWrapper").style.backgroundColor = "initial";	
+					document.getElementById("innerWrapper").style.backgroundColor = "initial";
 				},
 				restore: function () {
-					document.getElementById("innerWrapper").style.backgroundColor = "initial";	
+					document.getElementById("innerWrapper").style.backgroundColor = "initial";
 					link = document.getElementById("darkTheme");
 					if (!link) return;
 					link.disabled = true;
@@ -608,7 +608,7 @@ var toReturn = {
 					if (!game.global.mapsActive) return;
 					var setTo = (this.enabled) ? ["8", "2"] : ["10", "off"];
 					swapClass("col-xs", "col-xs-" + setTo[0], document.getElementById("gridContainer"));
-					swapClass("col-xs", "col-xs-" + setTo[1], document.getElementById("extraMapBtns"));				
+					swapClass("col-xs", "col-xs-" + setTo[1], document.getElementById("extraMapBtns"));
 				},
 				lockUnless: function () {
 					return (game.global.totalPortals > 0)
@@ -649,7 +649,7 @@ var toReturn = {
 				titles: ["Keep Fighting", "Map at Spire"],
 				lockUnless: function () {
 					return (game.global.highestLevelCleared >= 199);
-				}				
+				}
 			},
 			siphonologyMapLevel: {
 				enabled: 0,
@@ -705,7 +705,7 @@ var toReturn = {
 				enabled: 1,
 				extraTags: "general",
 				description: "Disable the snow effect in the world. <b>This will take effect on the next zone after this setting is changed</b>. This setting is temporary, and will melt when the snow does.",
-				titles: ["No Snow", "Show Snow"]			
+				titles: ["No Snow", "Show Snow"]
 			}, */
 			geneSend: {
 				enabled: 0,
@@ -991,8 +991,8 @@ var toReturn = {
 			icon: "italic",
 			requires: "skeletimp"
 		},
-		
-		
+
+
 
 	},
 	//portal
@@ -1036,7 +1036,7 @@ var toReturn = {
 			additive: true,
 			additiveInc: 500,
 			modifier: 0.01
-		},		
+		},
 		Toughness_II: {
 			level: 0,
 			locked: true,
@@ -1127,7 +1127,7 @@ var toReturn = {
 				timeOnZone = Math.floor(timeOnZone / 600000);
 				if (timeOnZone > 6) timeOnZone = 6;
 				else if (timeOnZone <= 0) return 0;
-				if (justStacks) return timeOnZone;				
+				if (justStacks) return timeOnZone;
 				return (timeOnZone * this.modifier * this.level);
 			}
 		},
@@ -1167,7 +1167,7 @@ var toReturn = {
 			tooltip: "Use your new-found leadership skills in order to increase the minimum damage your Trimps deal by 2% per level. Stacks up to 10 times, doesn't affect max damage. At 10 levels, you will get a minimum of 100% benefit from all attack damage per strike.",
 		},
 		Agility: {
-			level: 0, 
+			level: 0,
 			modifier: 0.05,
 			priceBase: 4,
 			heliumSpent: 0,
@@ -1330,7 +1330,7 @@ var toReturn = {
 			unlocks: "Carpentry",
 			unlockString: "reach Zone 35"
 		},
-		Balance: { 
+		Balance: {
 			description: "Your scientists have discovered a chaotic dimension filled with helium. All enemies have 100% more health, enemies in world deal 17% more damage, and enemies in maps deal 135% more damage. Starting at Zone 6, every time an enemy in the world is slain you will gain a stack of 'Unbalance'. Every time an enemy in a map is slain, you will lose a stack of Unbalance. Each stack of Unbalance reduces your health by 1%, but increases your Trimps' gathering speed by 1%. Unbalance can only stack to 250. Completing <b>Zone 40</b> with this challenge active will grant an additional 100% of all helium earned up to that point. This challenge is repeatable!",
 			completed: false,
 			filter: function () {
@@ -1374,7 +1374,7 @@ var toReturn = {
 			unlockString: "reach Zone 40"
 		},
 		Scientist: {
-			get description (){ 
+			get description (){
 				var is5 = (game.global.highestLevelCleared >= 124 && game.global.sLevel >= 4);
 				return "Attempt modifying the portal to " + ((is5) ? "retain positive qualities from previous dimensions" : "harvest resources when travelling") + ". Until you perfect the technique, you will start with <b>_</b> science but will be unable to research or hire scientists" + ((is5) ? " and <b style='color: maroon'>all enemy damage will be 10X higher</b>" : "") + ". Choose your upgrades wisely! Clearing <b>'The Block' (11)</b> with this challenge active will cause you to * each time you use your portal."
 			},
@@ -1726,8 +1726,8 @@ var toReturn = {
 			valueTotal: 0
 		},
 		gemsCollected: {
-			title: "Gems Collected", 
-			value: 0, 
+			title: "Gems Collected",
+			value: 0,
 			valueTotal: 0,
 			display: function () {
 				return ((this.value + this.valueTotal) > 0)
@@ -1883,7 +1883,7 @@ var toReturn = {
 			value: 0,
 			valueTotal: 0
 		}
-		
+
 	},
 	generatorUpgrades: {
 		Efficiency: {
@@ -1973,7 +1973,7 @@ var toReturn = {
 			description: "Reduce the amount of Magmite that decays after each portal by 10% (additive)",
 			cost: 1050,
 			owned: false
-		},	
+		},
 		Slowburn: {
 			description: "Reduce the rate of fuel consumption per tick by 0.1, from 0.5 to 0.4",
 			cost: 1875,
@@ -2007,7 +2007,7 @@ var toReturn = {
 			description: function (number) {
 				return "Reach " + prettify(this.breakpoints[number]) + " displayed damage";
 			},
-			progress: function () {				
+			progress: function () {
 				if (this.breakpoints.length > this.finished) return prettify(this.highest) + " / " + prettify(this.breakpoints[this.finished]);
 				return "Highest is " + prettify(this.highest);
 			},
@@ -2375,7 +2375,7 @@ var toReturn = {
 			names: ["Lover of Bots", "Friend of Bots", "Acquaintance of Bots", "Bot Disliker", "Bot Hater", "Bot Slayer"],
 			icon: "icomoon icon-alarmclock",
 			newStuff: []
-		},		
+		},
 		starTimed: {
 			finished: 0,
 			title: "Speed: Star",
@@ -2441,7 +2441,7 @@ var toReturn = {
 			newStuff: []
 		}
 	},
-	
+
 	heirlooms: { //Basic layout for modifiers. Steps can be set specifically for each modifier, or else default steps will be used
 		//NOTE: currentBonus is the only thing that will persist!
 		values: [10, 20, 30, 50, 150, 300, 800, 2000],
@@ -2562,10 +2562,10 @@ var toReturn = {
 				rarity: 1
 			}
 		}
-	
+
 	},
-	
-	
+
+
 	worldText: {
 		w2: "Your Trimps killed a lot of bad guys back there. It seems like you're getting the hang of this. However, the world is large, and there are many more zones to explore. Chop chop.",
 		w3: "By your orders, your scientists have begun to try and figure out how large this planet is.",
@@ -2579,7 +2579,7 @@ var toReturn = {
 		w11: "You're unstoppable as long as nothing stops you. Unfortunately, it seems like something really wants to stop you.",
 		w12: "Did you see that green light flash by? Weird. Oh well.",
 		w13: "Your scientists have finally concluded their report on the analysis of the size of the world. According to the report, they're pretty sure it's infinitely large, but you're pretty sure they just got bored of checking.",
-		w14: "You were trying to help bring back some of the Equipment your Trimps left on the ground in that last zone, and you got a splinter. This planet is getting dangerous, stay alert.",		
+		w14: "You were trying to help bring back some of the Equipment your Trimps left on the ground in that last zone, and you got a splinter. This planet is getting dangerous, stay alert.",
 		w15: "Another day, another Blimp at the end of the zone",
 		w16: "Seriously? Another Blimp so soon?",
 		w17: "You climb a large cliff and look out over the new zone. Red dirt, scorched ground, and devastation. Is that a Dragimp flying around out there?!",
@@ -2651,12 +2651,12 @@ var toReturn = {
 		w174: "Strange smells continue to swell around you. Judging by changes in wind direction, the smells are coming from the spire. You still can't describe it other than purple.",
 		w175: "Your Trimps seem happy. They're not used to having a purpose, and having one seems to positively affect them! You call a Trimp over and ask him how he's doing, then you remember that he can't talk.",
 		w178: "You're still not quite sure what that smell is. You feel slightly more powerful, and you fear that your enemies may feel the same way.",
-		get w180 () { 
+		get w180 () {
 		if (game.global.challengeActive != "Corrupted") return "After clearing out the previous zone, you decide to take a day hike to the top of another gigantic mountain to try to find more info about the smell. As you reach the top, your jaw drops. Clear as day, a healthy amount of purple goo is pouring into the atmosphere from the top of the spire. You can see the zones in front of you beginning to change. This really can't be good.";
 		return "After clearing out the previous zone, you decide to take a day hike to the top of another gigantic mountain to try to find more info about the smell. As you reach the top, your jaw drops. Clear as day, a healthy amount of purple goo is pouring into the atmosphere from the top of the spire. This must be what's causing all of this Corruption you've been trudging through. The planet seems pretty heavily Corrupted already, you wonder if you're too late.";
 		},
 		w182: "Well, there's not really much doubt about it anymore. Some sort of intelligence is intentionally making life more difficult for you and your Trimps. You take this as a sign that you're pretty important, why else would something risk destroying an entire planet to stop you? Your parents would be so proud.",
-		get w184 () { 
+		get w184 () {
 				return "The corruption seems to be more pronounced the closer you get to the Spire. Looks like there's " + mutations.Corruption.cellCount() + " of em now."
 			},
 		w185: "You have trouble putting in to words exactly what the Corruption does to the creatures on this planet. They seem to be stripped of all natural abilities and given powers that you didn't know could exist in the primary dimension.",
@@ -2691,16 +2691,16 @@ var toReturn = {
 		w255: "Your Trimps continue to lose strength as you press through the zones, but they seem to be adapting well in spirits. It seems like each generation likes the heat more and more.",
 		w265: "You're determined to repair the planet, though you feel like it's not yet possible. Either way, you know you're gaining strength and that your Trimps would follow you anywhere."
 	},
-	
+
 	trimpDeathTexts: ["ceased to be", "bit the dust", "took a dirt nap", "expired", "kicked the bucket", "evaporated", "needed more armor", "exploded", "melted", "fell over", "swam the river Styx", "turned in to jerky", "forgot to put armor on", "croaked", "flatlined", "won't follow you to battle again", "died. Lame", "lagged out", "imp-loded"],
 	badGuyDeathTexts: ["slew", "killed", "destroyed", "extinguished", "liquidated", "vaporized", "demolished", "ruined", "wrecked", "obliterated"],
-	
+
 	settings: {
 		speed: 10,
 		speedTemp: 0,
 		slowdown: false,
 	},
-	
+
 	resources: {
 		food: {
 			owned: 0,
@@ -2747,9 +2747,9 @@ var toReturn = {
 		helium: {
 			owned: 0,
 			max: -1
-		} 
+		}
 	},
-	
+
 	magma: {
 		buffs: {
 			attack: 0,
@@ -2758,7 +2758,7 @@ var toReturn = {
 			potency: 0
 		}
 	},
-	
+
 	equipment: {
 		Shield: {
 			locked: 1,
@@ -3083,7 +3083,7 @@ var toReturn = {
 			fast: true,
 			loot: function (level) {
 				var amt = rewardResource("gems", 0.3, level, true);
-				message("That Slagimp fell over, and " + prettify(amt) + " gems popped out! How about that?!", "Loot", "*diamond", null, 'secondary'); 
+				message("That Slagimp fell over, and " + prettify(amt) + " gems popped out! How about that?!", "Loot", "*diamond", null, 'secondary');
 			}
 		},
 		Moltimp: {
@@ -3170,7 +3170,7 @@ var toReturn = {
 			loot: function (level) {
 				var amt = rewardResource("food", 0.35, level, true);
 				message("Time for some stew! You scored " + prettify(amt) + " food from that Squirrimp!", "Loot", "apple", null, 'primary');
-			}			
+			}
 		},
 		Gravelimp: {
 			location: "Plentiful",
@@ -3221,7 +3221,7 @@ var toReturn = {
 				var amt = (game.global.world >= 60) ? 10 : 2;
 				if (mutations.Magma.active()) amt *= 3;
 				var percentage = 1;
-				if (game.global.world >= mutations.Corruption.start(true)){ 
+				if (game.global.world >= mutations.Corruption.start(true)){
 					percentage = (game.global.challengeActive == "Corrupted") ? 0.075 : 0.15;
 					percentage *= mutations.Corruption.cellCount() * 2;
 					percentage += 2;
@@ -3398,7 +3398,7 @@ var toReturn = {
 			fast: false,
 			loot: function (level) {
 				var amt = rewardResource("metal", .25, level, true);
-				message("Destructimp shorted out. Salvage results: " + prettify(amt) + " bars of metal. Acceptable.", "Loot", "*cubes", null, 'primary');				
+				message("Destructimp shorted out. Salvage results: " + prettify(amt) + " bars of metal. Acceptable.", "Loot", "*cubes", null, 'primary');
 			}
 		},
 		Terminatimp: {
@@ -3409,7 +3409,7 @@ var toReturn = {
 			fast: false,
 			loot: function (level) {
 				var amt = rewardResource("metal", .25, level, true);
-				message("Terminatimp Terminated. Findings: " + prettify(amt) + " bars of metal. Hasta la Vista.", "Loot", "*cubes", null, 'primary');				
+				message("Terminatimp Terminated. Findings: " + prettify(amt) + " bars of metal. Hasta la Vista.", "Loot", "*cubes", null, 'primary');
 			}
 		},
 		Autoimp: {
@@ -3464,7 +3464,7 @@ var toReturn = {
 			fast: true,
 			loot: function (level) {
 				var amt = rewardResource("metal", .5, level, true);
-				message("The Fusimp explodes, leaving behind " + prettify(amt) + " bars of metal and a nice dose of radiation.", "Loot", "*cubes", null, 'primary');				
+				message("The Fusimp explodes, leaving behind " + prettify(amt) + " bars of metal and a nice dose of radiation.", "Loot", "*cubes", null, 'primary');
 			}
 		},
 		Hydrogimp: {
@@ -3475,8 +3475,8 @@ var toReturn = {
 			fast: false,
 			loot: function (level) {
 				var amt = rewardResource("food", 1, level, true);
-				message("Before you can blink, the Hydrogimp vaporizes. That's fine though, it left " + prettify(amt) + " food for you!", "Loot", "apple", null, 'primary');				
-			}			
+				message("Before you can blink, the Hydrogimp vaporizes. That's fine though, it left " + prettify(amt) + " food for you!", "Loot", "apple", null, 'primary');
+			}
 		},
 		Carbimp: {
 			location: "Star",
@@ -3486,8 +3486,8 @@ var toReturn = {
 			fast: true,
 			loot: function (level) {
 				var amt = rewardResource("wood", 1, level, true);
-				message("The Carbimp begins to crackle and shrink. Within a few seconds, all that's left is " + prettify(amt) + " wood.", "Loot", "tree-deciduous", null, 'primary');				
-			}		
+				message("The Carbimp begins to crackle and shrink. Within a few seconds, all that's left is " + prettify(amt) + " wood.", "Loot", "tree-deciduous", null, 'primary');
+			}
 		},
 		//End Imploding Star stuff
 		Improbability: {
@@ -3504,7 +3504,7 @@ var toReturn = {
 				if (game.global.runningChallengeSquared) return;
 				var amt = (game.global.world >= mutations.Corruption.start(true)) ? 10 : 5;
 				amt = rewardResource("helium", amt, level);
-				message("You managed to steal " + prettify(amt) + " Helium canisters from that Improbability. That'll teach it.", "Loot", "oil", 'helium', 'helium');				
+				message("You managed to steal " + prettify(amt) + " Helium canisters from that Improbability. That'll teach it.", "Loot", "oil", 'helium', 'helium');
 				if (game.global.challengeActive == "Slow" && game.global.world == 120){
 					message("You have completed the Slow challenge! You have found the patterns for the Gambeson and the Arbalest!", "Notices");
 					game.global.challengeActive = "";
@@ -3640,7 +3640,7 @@ var toReturn = {
 				if (game.portal.Carpentry.level) amt *= Math.pow((1 + game.portal.Carpentry.modifier), game.portal.Carpentry.level);
 				if (game.portal.Carpentry_II.level > 0) amt *= (1 + (game.portal.Carpentry_II.modifier * game.portal.Carpentry_II.level));
 				message("It's nice, warm, and roomy in that dead Tauntimp. It's big enough for " + prettify(amt) + " Trimps to live inside!", "Loot", "gift", "exotic", "exotic");
-				
+
 			}
 		},
 		Whipimp: {
@@ -3661,7 +3661,7 @@ var toReturn = {
 				game.jobs.Explorer.modifier *= 1.003;
 				var amt = Math.pow(1.003, game.unlocks.impCount.Whipimp);
 				amt = (amt - 1) * 100;
-				message("Seeing the Whipimps fall is causing all of your Trimps to work " + amt.toFixed(2) + "% harder!", "Loot", "star", "exotic", "exotic");			
+				message("Seeing the Whipimps fall is causing all of your Trimps to work " + amt.toFixed(2) + "% harder!", "Loot", "star", "exotic", "exotic");
 			}
 		},
 		Venimp: {
@@ -3676,7 +3676,7 @@ var toReturn = {
 				game.unlocks.impCount.Venimp++;
 				var amt = Math.pow(1.003, game.unlocks.impCount.Venimp);
 				amt = (amt - 1) * 100;
-				message("The ground up Venimp now increases your Trimps' breed speed by " + amt.toFixed(2) + "%!", "Loot", "glass", "exotic", "exotic");			
+				message("The ground up Venimp now increases your Trimps' breed speed by " + amt.toFixed(2) + "%!", "Loot", "glass", "exotic", "exotic");
 			}
 		},
 		Jestimp: {
@@ -3717,7 +3717,7 @@ var toReturn = {
 				else timeRemaining = 30;
 				game.global.titimpLeft = timeRemaining;
 				message("That Titimp made your Trimps super strong!", "Loot", "*hammer", "exotic", "exotic");
-			}		
+			}
 		},
 		Chronoimp: {
 			location: "Maps",
@@ -3743,8 +3743,8 @@ var toReturn = {
 					else cMessage += ", ";
 				}
 				message(cMessage, "Loot", "hourglass", "exotic", "exotic");
-				game.unlocks.impCount.Chronoimp++;				
-			}		
+				game.unlocks.impCount.Chronoimp++;
+			}
 		},
 		Magnimp: {
 			location: "World",
@@ -3759,7 +3759,7 @@ var toReturn = {
 				var amt = Math.pow(1.003, game.unlocks.impCount.Magnimp);
 				amt = (amt - 1) * 100;
 				message("You killed a Magnimp! The strong magnetic forces now increase your loot by " + amt.toFixed(2) + "%!", "Loot", "magnet", "exotic", "exotic");
-			}		
+			}
 		},
 		Skeletimp: {
 			location: "World",
@@ -3789,22 +3789,22 @@ var toReturn = {
 				updateSkeleBtn();
 			}
 		}
-		
+
 	},
-	
+
 	mapConfig: {
 		names: {
-			prefix: ["Whispering", "Sandy", "Little", "Big", "Rancid", "Tired", "Laughing", "Weeping", "Windy", "Terrible", "Nasty", "Dirty", 
-			"Red", "Black", "Singing", "Fiery", "Rocky", "Haunted", "Forgotten", "Miserable", "Cursed", "Tainted", "Blessed", "Sacred", 
-			"Abandoned", "Natural", "Enchanted", "Magical", "Calm", "Rugged", "Violent", "Weird", "Secret", "Forbidden", "Bewitched", 
-			"Dark", "Light", "Magnificent", "Evil", "Holy", "Hallowed", "Desecrated", "Silent", "Eternal", "Underground", "Temperate", "Chilly", 
+			prefix: ["Whispering", "Sandy", "Little", "Big", "Rancid", "Tired", "Laughing", "Weeping", "Windy", "Terrible", "Nasty", "Dirty",
+			"Red", "Black", "Singing", "Fiery", "Rocky", "Haunted", "Forgotten", "Miserable", "Cursed", "Tainted", "Blessed", "Sacred",
+			"Abandoned", "Natural", "Enchanted", "Magical", "Calm", "Rugged", "Violent", "Weird", "Secret", "Forbidden", "Bewitched",
+			"Dark", "Light", "Magnificent", "Evil", "Holy", "Hallowed", "Desecrated", "Silent", "Eternal", "Underground", "Temperate", "Chilly",
 			"Muddy", "Dank", "Steamy", "Humid", "Dry", "Putrid", "Foul", "Dangerous", "Marred", "Blighted", "Crystal", "Frozen", "Simple", "Timeless"],
-			suffix: ["Creek.Sea", "Coast.Sea", "Swamp.Sea", "Forest.Forest", "Mountain.Mountain", "Beach.Sea", "Hill.Mountain", "Butte.Mountain", 
-			"Ridge.Mountain", "Mesa.Mountain", "Valley.Depths", "Peak.Mountain", "Canyon.Depths", "Plateau.Mountain", "Crag.Depths", 
-			"Crater.Depths", "Oaks.Forest",  "Volcano.Mountain", "Glacier.Sea",  "Brook.Sea", "Cave.Depths",  "Sea.Sea", "Ocean.Sea", 
-			"Lake.Sea", "Jungle.Forest", "Island.Sea", "Ruins.Depths", "Temple.Depths", "Bog.Sea", "Grove.Forest", "Jungle.Forest", 
-			"Thicket.Forest", "Woods.Forest", "Oasis.Forest", "Mineshaft.Depths", "Tunnel.Depths", "Depths.Depths", "Cavern.Depths", 
-			"Gardens.Plentiful", "Gardens.Plentiful", "Gardens.Plentiful", "Gardens.Plentiful", "Gardens.Plentiful", "Gardens.Plentiful", 
+			suffix: ["Creek.Sea", "Coast.Sea", "Swamp.Sea", "Forest.Forest", "Mountain.Mountain", "Beach.Sea", "Hill.Mountain", "Butte.Mountain",
+			"Ridge.Mountain", "Mesa.Mountain", "Valley.Depths", "Peak.Mountain", "Canyon.Depths", "Plateau.Mountain", "Crag.Depths",
+			"Crater.Depths", "Oaks.Forest",  "Volcano.Mountain", "Glacier.Sea",  "Brook.Sea", "Cave.Depths",  "Sea.Sea", "Ocean.Sea",
+			"Lake.Sea", "Jungle.Forest", "Island.Sea", "Ruins.Depths", "Temple.Depths", "Bog.Sea", "Grove.Forest", "Jungle.Forest",
+			"Thicket.Forest", "Woods.Forest", "Oasis.Forest", "Mineshaft.Depths", "Tunnel.Depths", "Depths.Depths", "Cavern.Depths",
+			"Gardens.Plentiful", "Gardens.Plentiful", "Gardens.Plentiful", "Gardens.Plentiful", "Gardens.Plentiful", "Gardens.Plentiful",
 			"Gardens.Plentiful", "Gardens.Plentiful", "Gardens.Plentiful", "Gardens.Plentiful"]
 		},
 		locations: {
@@ -3866,7 +3866,7 @@ var toReturn = {
 		lootBase: 1.3,
 		lootRange: 0.3
 	},
-	
+
 	mapUnlocks: {
 		roboTrimp: {
 			world: 125,
@@ -3887,7 +3887,7 @@ var toReturn = {
 			},
 			createMap: function(tier) {
 				game.global.bionicOwned++;
-				if (game.global.bionicOwned == 1) 
+				if (game.global.bionicOwned == 1)
 					message("You found a map to the Bionic Wonderland. Sounds fun!", "Story");
 				else
 					message("You found a map to an even more advanced version of the Bionic Wonderland! Looks scary... Your scientists remind you that you can only carry 3 of these incredibly heavy, metallic maps at a time.", "Story");
@@ -3915,7 +3915,7 @@ var toReturn = {
 						game.global.roboTrimpLevel++;
 						var values = game.global.roboTrimpLevel;
 						values = [(values) * 20, ((1 - this.getShriekValue()) * 100).toFixed(1)];
-						message("<span class='icomoon icon-chain'></span> Hey look, another baby RoboTrimp! You decide to add him to your collection. You now deal " + Math.floor(values[0]) + "% extra damage thanks to your pets, and MagnetoShriek now removes " + Math.floor(values[1]) + "% of an Improbability's attack", "Notices");					
+						message("<span class='icomoon icon-chain'></span> Hey look, another baby RoboTrimp! You decide to add him to your collection. You now deal " + Math.floor(values[0]) + "% extra damage thanks to your pets, and MagnetoShriek now removes " + Math.floor(values[1]) + "% of an Improbability's attack", "Notices");
 					}
 				}
 			}
@@ -3955,7 +3955,7 @@ var toReturn = {
 				document.getElementById("autoStorageBtn").style.display = "block";
 				createHeirloom();
 				message("You found an Heirloom!", "Loot", "*archive", null, "secondary", null, null, true);
-			}	
+			}
 		},
 		ImprovedAutoStorage: {
 			world: 150,
@@ -3973,7 +3973,7 @@ var toReturn = {
 				enableImprovedAutoStorage();
 				createHeirloom();
 				message("You found an Heirloom!", "Loot", "*archive", null, "secondary");
-			}	
+			}
 		},
 		AncientTreasure: {
 			world: 33,
@@ -3991,7 +3991,7 @@ var toReturn = {
 				addResCheckMax("metal", game.resources.metal.owned);
 				message("After barely escaping a fierce boulder, you check out the relic you found in there. It glows extremely bright for a few seconds before disappearing, and you look at your storages to see that your Food, Wood, and Metal have been doubled!", "Story", "piggy-bank", "highlightStoryMessage");
 			}
-			
+
 		},
 		Heirloom: {
 			world: 6,
@@ -4055,7 +4055,7 @@ var toReturn = {
 				fadeIn("helium", 10);
 				addHelium(45);
 				if (!fromGenerator){
-					message("<span class='glyphicon glyphicon-oil'></span> You were able to extract 45 Helium canisters from that Blimp! Now that you know how to do it, you'll be able to extract helium from normal Blimps.", "Story"); 
+					message("<span class='glyphicon glyphicon-oil'></span> You were able to extract 45 Helium canisters from that Blimp! Now that you know how to do it, you'll be able to extract helium from normal Blimps.", "Story");
 				}
 				if (game.global.challengeActive == "Metal"){
 					game.global.challengeActive = "";
@@ -4104,7 +4104,7 @@ var toReturn = {
 				if (game.global.challengeActive == "Scientist"){
 					game.global.challengeActive = "";
 					game.global.sLevel = getScientistLevel();
-					game.challenges.Scientist.abandon();					
+					game.challenges.Scientist.abandon();
 					message("You have completed the <b>Scientist Challenge!</b> From now on, you'll " + getScientistInfo(game.global.sLevel, true) + " every time you portal. You've unlocked Scientists, and <b>Don't forget that you can click Research on your Science again!</b>", "Notices");
 				}
 				if (game.global.challengeActive == "Trimp"){
@@ -4187,7 +4187,7 @@ var toReturn = {
 			fire: function () {
 				unlockUpgrade("Hellishmet");
 			}
-		},		
+		},
 		Polierarm: {
 			world: -1,
 			message: "You found a book that will teach you how to upgrade your Polearm!",
@@ -4300,7 +4300,7 @@ var toReturn = {
 			canRunOnce: true,
 			fire: function () {
 				message("You just made a map to The Block!", "Story");
-				createMap(11, "The Block", "Block", 2, 100, 1.3, true, true); 
+				createMap(11, "The Block", "Block", 2, 100, 1.3, true, true);
 			}
 		},
 		TheWall: {
@@ -4313,7 +4313,7 @@ var toReturn = {
 			canRunOnce: true,
 			fire: function () {
 				message("You just made a map to The Wall!", "Story");
-				createMap(15, "The Wall", "Wall", 2, 100, 1.5, true, true); 
+				createMap(15, "The Wall", "Wall", 2, 100, 1.5, true, true);
 			}
 		},
 		ThePrison: {
@@ -4391,7 +4391,7 @@ var toReturn = {
 			}
 		},
 		UberHouse: {
-			world: -1, 
+			world: -1,
 			startAt: 29,
 			message: "This book talks about adding a second floor to your homes! Mind... blown...",
 			level: [10, 20],
@@ -4403,7 +4403,7 @@ var toReturn = {
 			}
 		},
 		UberMansion: {
-			world: -1, 
+			world: -1,
 			startAt: 34,
 			message: "This book will teach you how to make your Trimps share their mansions!",
 			level: [10, 20],
@@ -4500,9 +4500,9 @@ var toReturn = {
 			canRunOnce: true,
 			fire: function () {
 				unlockUpgrade("Trapstorm");
-			}	
+			}
 		},
-		
+
 		Nursery: {
 			world: -1,
 			startAt: 23,
@@ -4550,7 +4550,7 @@ var toReturn = {
 			fire: function (level) {
 				var rand = Math.floor(Math.random() * 3);
 				switch(rand) {
-					case 0: 
+					case 0:
 						game.mapUnlocks.Food.fire(level);
 						break;
 					case 1:
@@ -4610,7 +4610,7 @@ var toReturn = {
 			world: 1,
 			title: "New Armor",
 			level: 4,
-			icon: "question-sign"		
+			icon: "question-sign"
 		},
 		Boots: {
 			message: "You found plans for Boots! Swell!",
@@ -4826,12 +4826,12 @@ var toReturn = {
 		Trainer: {
 			message: "You found a book about proper physical training!",
 			world: 3,
-			level: 3, 
+			level: 3,
 			icon: "book",
 			title: "Step Up Your Block Game!",
 			fire: function () {
 				unlockUpgrade("Trainers");
-			}		
+			}
 		},
 		Scientist: {
 			message: "You found a book about Einstrimp!",
@@ -4857,7 +4857,7 @@ var toReturn = {
 			fire: function () {
 				if (game.upgrades.Explorers.allowed === 0) unlockUpgrade("Explorers");
 			}
-		},		
+		},
 		Speedscience: {
 			message: "You found a book called Speedscience! What do you think it could possibly do?!",
 			brokenPlanet: -1,
@@ -5128,7 +5128,7 @@ var toReturn = {
 			icon: "th-large",
 			title: "Too dark to see",
 			fire: function () {
-				createMap(33, "Trimple Of Doom", "Doom", 3, 100, 1.8, true); 
+				createMap(33, "Trimple Of Doom", "Doom", 3, 100, 1.8, true);
 				message("There is something strange about this map. It doesn't seem to reflect any light at all, just pure darkness.", "Story");
 			}
 		},
@@ -5348,7 +5348,7 @@ var toReturn = {
 				food: [3000, 1.2],
 				wood: [2000, 1.2],
 				metal: [500, 1.2]
-				
+
 			},
 			increase: {
 				what: "trimps.max",
@@ -5367,7 +5367,7 @@ var toReturn = {
 				food: [10000, 1.18],
 				wood: [12000, 1.18],
 				metal: [5000, 1.18]
-				
+
 			},
 			increase: {
 				what: "trimps.max",
@@ -5386,7 +5386,7 @@ var toReturn = {
 				food: [100000, 1.16],
 				wood: [120000, 1.16],
 				metal: [50000, 1.16]
-				
+
 			},
 			increase: {
 				what: "trimps.max",
@@ -5454,10 +5454,10 @@ var toReturn = {
 				metal: [1000000000000000, 1.4]
 			},
 			increase: {
-				what: "trimps.max", 
+				what: "trimps.max",
 				by: 10000
 			}
-		
+
 		},
 		Gym: {
 			locked: 1,
@@ -5477,7 +5477,7 @@ var toReturn = {
 				if (game.upgrades.Gymystic.done === 0) return;
 				var oldBlock = game.buildings.Gym.increase.by;
 				game.buildings.Gym.increase.by *= (game.upgrades.Gymystic.modifier + (0.01 * (game.upgrades.Gymystic.done - 1)));
-				game.global.block += ((game.buildings.Gym.increase.by - oldBlock) * (game.buildings.Gym.owned));		
+				game.global.block += ((game.buildings.Gym.increase.by - oldBlock) * (game.buildings.Gym.owned));
 			}
 		},
 		Tribute: {
@@ -5505,7 +5505,7 @@ var toReturn = {
 				if (mutations.Magma.active())
 					return "<p>Magma is generally not conductive to a healthy Nursery environment. Each Nursery will still increase Trimps per second from breeding by 1% (compounding), but 10% of your active Nurseries will shut down each zone as the Magma moves closer. Safety first!</p><p>You have purchased " + prettify(this.purchased) + " total Nurseries.</p>";
 				return "Construct a gem-powered nursery, where baby Trimps can grow up faster. Increases Trimps per second from breeding by 1% (compounding).";
-				
+
 			},
 			cost: {
 				gems: [400000, 1.06],
@@ -5648,10 +5648,10 @@ var toReturn = {
 				else timeOnZone = forceTime;
 				if (justStacks) return timeOnZone;
 				return 1 + ((((1 - Math.pow(boostMult, this.owned)) * boostMax)) * (Math.pow(expInc, timeOnZone) - 1));
-			}			
+			}
 		}
 	},
-	
+
 	goldenUpgrades: {
 		Helium: {
 			tooltip: function() {
@@ -5684,7 +5684,7 @@ var toReturn = {
 			purchasedAt: []
 		}
 	},
-	
+
 	upgrades: {
 	//Important Upgrades
 		Coordination: {
@@ -5732,7 +5732,7 @@ var toReturn = {
 				if ((ctrlPressed || heldCtrl) && oldAmt > 1) buyBuilding("Warpstation", false, false, oldAmt - 1);
 			}
 		},
-		
+
 	//One Time Use Upgrades, in order of common unlock order
 		Battle: { //0
 			locked: 1,
@@ -5802,7 +5802,7 @@ var toReturn = {
 					science: 10000,
 					food: 100000,
 					wood: 100000
-					
+
 				}
 			},
 			fire: function () {
@@ -5853,7 +5853,7 @@ var toReturn = {
 				game.jobs.Miner.modifier *= 2;
 				game.jobs.Scientist.modifier *= 2;
 				game.jobs.Explorer.modifier *= 2;
-				
+
 			}
 		},
 		Egg: { //17
@@ -5885,9 +5885,9 @@ var toReturn = {
 			},
 			fire: function () {
 				message("You just made a map to the Dimension of Anger! Should be fun!", "Notices");
-				createMap(20, "Dimension of Anger", "Hell", 3, 100, 2.5, true, true); 
+				createMap(20, "Dimension of Anger", "Hell", 3, 100, 2.5, true, true);
 			}
-		},		
+		},
 		Gymystic: { //25
 			locked: 1,
 			allowed: 0,
@@ -5909,7 +5909,7 @@ var toReturn = {
 		SuperShriek: {
 			locked: 1,
 			allowed: 0,
-			get tooltip (){ 
+			get tooltip (){
 				var text = "This book will teach your Robotrimp how to do a much better job of shrieking, allowing MagnetoShriek to be used on multiple Corrupted cells in addition to Improbabilities. Upgraded MagnetoShriek starts off only being able to affect 1 cell at a time, but each use after purchasing this upgrade will extend the bonus by one additional cell, up to a max of 5 cells (resets on portal). <br/><br/> Each new Bionic Wonderland clear starting at Z185 will permanently increase the cell count cap by 1.";
 				var cap = 5;
 				if (game.global.roboTrimpLevel >= 5)
@@ -5944,7 +5944,7 @@ var toReturn = {
 				resources: {
 					science: 20000000000,
 					food: 200000000000
-				}			
+				}
 			},
 			fire: function () {
 				unlockFormation(2);
@@ -5959,8 +5959,8 @@ var toReturn = {
 				resources: {
 					science: 40000000000,
 					food: 400000000000
-				}			
-			},	
+				}
+			},
 			fire: function () {
 				unlockFormation(3);
 			}
@@ -5995,7 +5995,7 @@ var toReturn = {
 			},
 			fire: function () {
 				unlockJob("Scientist");
-			}			
+			}
 		},
 		Trainers: {
 			locked: 1,
@@ -6386,7 +6386,7 @@ var toReturn = {
 			},
 			fire: function () {
 				game.global.playerModifier *= 2;
-			}			
+			}
 		},
 		Speedminer: {
 			locked: 1,
@@ -6401,7 +6401,7 @@ var toReturn = {
 			},
 			fire: function () {
 				game.jobs.Miner.modifier *= 1.25;
-			}			
+			}
 		},
 		Speedlumber: {
 			locked: 1,
@@ -6416,7 +6416,7 @@ var toReturn = {
 			},
 			fire: function () {
 				game.jobs.Lumberjack.modifier *= 1.25;
-			}			
+			}
 		},
 		Speedfarming: {
 			locked: 1,
@@ -6431,7 +6431,7 @@ var toReturn = {
 			},
 			fire: function () {
 				game.jobs.Farmer.modifier *= 1.25;
-			}			
+			}
 		},
 		Speedscience: {
 			locked: 1,
@@ -6445,7 +6445,7 @@ var toReturn = {
 			},
 			fire: function () {
 				game.jobs.Scientist.modifier *= 1.25;
-			}			
+			}
 		},
 		Megaminer: {
 			locked: 1,
@@ -6461,8 +6461,8 @@ var toReturn = {
 			fire: function () {
 				var amt = (game.global.frugalDone) ? 1.6 : 1.5;
 				game.jobs.Miner.modifier *= amt;
-			}			
-		},	
+			}
+		},
 		Megalumber: {
 			locked: 1,
 			allowed: 0,
@@ -6477,8 +6477,8 @@ var toReturn = {
 			fire: function () {
 				var amt = (game.global.frugalDone) ? 1.6 : 1.5;
 				game.jobs.Lumberjack.modifier *= amt;
-			}			
-		},	
+			}
+		},
 		Megafarming: {
 			locked: 1,
 			allowed: 0,
@@ -6493,7 +6493,7 @@ var toReturn = {
 			fire: function () {
 				var amt = (game.global.frugalDone) ? 1.6 : 1.5;
 				game.jobs.Farmer.modifier *= amt;
-			}			
+			}
 		},
 		Megascience: {
 			locked: 1,
@@ -6508,7 +6508,7 @@ var toReturn = {
 			fire: function () {
 				var amt = (game.global.frugalDone) ? 1.6 : 1.5;
 				game.jobs.Scientist.modifier *= amt;
-			}			
+			}
 		},
 	},
 
@@ -6537,7 +6537,7 @@ var toReturn = {
 			},
 			fire: function () {
 				fadeIn("wood", 10);
-				
+
 			}
 		},
 		Barn: {
@@ -6662,7 +6662,7 @@ var toReturn = {
 			done: 0,
 			message: function () {
 				if (game.global.challengeActive == "Trapper") return "Your Trimps look really bored.";
-				else return "Apparently the Trimps breed if they're not working. Doesn't look pleasant.";		
+				else return "Apparently the Trimps breed if they're not working. Doesn't look pleasant.";
 			},
 			cost: {
 				special: function () {

--- a/main.js
+++ b/main.js
@@ -6780,6 +6780,16 @@ handleStatChanges: function handleStatChanges() {
 	}
 },
 
+/**
+ * Updates UI.
+ * @param  {Cell} cell Cell of current bad guy
+ */
+updateStartFightChallenges: function updateStartFightChallenges(cell) {
+	if (game.global.challengeActive == "Balance") updateBalanceStacks();
+	if (game.global.challengeActive == "Toxicity") updateToxicityStacks();
+	if (game.global.challengeActive == "Nom" && cell.nomStacks) updateNomStacks(cell.nomStacks);
+},
+
 get soldierNum() {
 	return (game.portal.Coordinated.level) ? game.portal.Coordinated.currentSend: game.resources.trimps.maxSoldiers;
 },
@@ -6813,10 +6823,7 @@ function startFight() {
 	document.getElementById("badGuyName").innerHTML = fightNS.getBadName(cell);
 	var corruptionStart = mutations.Corruption.start(true);
 	fightNS.setCorruptionBuffUI(cell, map);
-
-	if (game.global.challengeActive == "Balance") updateBalanceStacks();
-	if (game.global.challengeActive == "Toxicity") updateToxicityStacks();
-	if (game.global.challengeActive == "Nom" && cell.nomStacks) updateNomStacks(cell.nomStacks);
+	fightNS.updateStartFightChallenges();
 
 	var instaFight;
     if (cell.maxHealth == -1) {

--- a/main.js
+++ b/main.js
@@ -6168,20 +6168,7 @@ function startFight() {
         cell = game.global.gridArray[cellNum];
         cellElem = document.getElementById("cell" + cellNum);
 		if (cellElem == null){ //Not sure what causes this to be needed, but on very rare occasions, this can prevent some save files from freezing on load
-			if (game.global.lastClearedCell != 99) {
-				 if (game.global.lastClearedCell == -1){
-					buildGrid();
-					drawGrid();
-					document.getElementById("battleContainer").style.visibility = "visible";
-					document.getElementById('metal').style.visibility = "visible";
-					console.log("Attempted to fight in World when no grid was initialized. Find an adult");
-				}
-				return;
-			}
-			nextWorld();
-			game.stats.zonesCleared.value++;
-			checkAchieve("totalZones");
-			console.log("crisis averted");
+			cellElemNullError();
 			return;
 		}
     }
@@ -6501,6 +6488,26 @@ function startFight() {
     game.global.fighting = true;
     game.global.lastFightUpdate = new Date();
 	if (instaFight) fight();
+}
+/**
+ * Handles when cellElem == null, and brings game back into defined state
+ */
+function cellElemNullError() {
+	if (game.global.lastClearedCell != 99) {
+		 if (game.global.lastClearedCell == -1){
+			buildGrid();
+			drawGrid();
+			document.getElementById("battleContainer").style.visibility = "visible";
+			document.getElementById('metal').style.visibility = "visible";
+			console.log("Attempted to fight in World when no grid was initialized. Find an adult");
+		}
+		return;
+	}
+	nextWorld();
+	game.stats.zonesCleared.value++;
+	checkAchieve("totalZones");
+	console.log("crisis averted");
+	return;
 }
 
 function updateAllBattleNumbers (skipNum) {

--- a/main.js
+++ b/main.js
@@ -6167,10 +6167,7 @@ var lastSoldierSentAt =  new Date().getTime();
 function startFight() {
 	game.global.battleCounter = 0;
     document.getElementById("badGuyCol").style.visibility = "visible";
-    var cellNum;
-    var cell;
-    var cellElem;
-	var instaFight;
+    var cellNum, cell, cellElem;
 	var madeBadGuy = false;
 	var map = false;
     if (game.global.mapsActive) {
@@ -6192,14 +6189,15 @@ function startFight() {
 
 	document.getElementById("badGuyName").innerHTML = getBadName(cell);
 	var corruptionStart = mutations.Corruption.start(true);
-	setCorruptionBuffUI(cell, map, corruptionStart);
+	setCorruptionBuffUI(cell, corruptionStart, map);
 
 	if (game.global.challengeActive == "Balance") updateBalanceStacks();
 	if (game.global.challengeActive == "Toxicity") updateToxicityStacks();
 	if (game.global.challengeActive == "Nom" && cell.nomStacks) updateNomStacks(cell.nomStacks);
 
+	var instaFight;
     if (cell.maxHealth == -1) {
-		instaFight = spawnBadGuy(cell);
+		instaFight = spawnBadGuy(cell, corruptionStart, map);
 		madeBadGuy = true;
     }
 
@@ -6304,8 +6302,9 @@ function getBadName(cell) {
 	if (cell.mutation) {
 		badName = "<span class='badNameMutation " + cell.mutation + "'>" + mutations[cell.mutation].namePrefix + " " + displayedName + "</span>";
 	}
-	else
+	else {
 		badName = displayedName;
+	}
 	if (cell.empowerment){
 		badName = getEmpowerment(-1, true) + " " + badName;
 		badName = "<span class='badName" + getEmpowerment(-1) + "'>" + badName + "</span>";
@@ -6352,10 +6351,10 @@ function cellElemNullError() {
 /**
  * Sets the contents of '#corruptionBuff', from inputs & globals
  * @param {Cell} cell            Cell the bad guy is in
- * @param {Object} map             Map the cell is in
  * @param {Number} corruptionStart Zone where corruption starts
+ * @param {Object} [map]             Map the cell is in
  */
-function setCorruptionBuffUI(cell, map, corruptionStart) {
+function setCorruptionBuffUI(cell, corruptionStart, map) {
 	if (cell.mutation) {
 		setMutationTooltip(cell.corrupted, cell.mutation);
 	} else if (map && map.location == "Void" && game.global.world >= corruptionStart){
@@ -6370,9 +6369,11 @@ function setCorruptionBuffUI(cell, map, corruptionStart) {
 /**
  * Spawns a new bad guy in place in cell, and sets globals
  * @param  {Cell} cell Cell to spawn bad guy in
- * @return {Boolean} instaFight
+ * @param  {Number} corruptionStart Zone where corruption starts
+ * @param  {Object|null} [map=null] Map the cell is in,
+spawnbadguy * @return {Boolean} instaFight
  */
-function spawnBadGuy(cell) {
+function spawnBadGuy(cell, corruptionStart, map) {
 	var overkill = 0;
 
 	if (cell.health != -1) overkill = cell.health;
@@ -6547,7 +6548,7 @@ function spawnTrimps() {
 	game.global.soldierCurrentBlock = calcHeirloomBonus("Shield", "trimpBlock", game.global.soldierCurrentBlock);
 	if (game.global.challengeActive == "Daily" && typeof game.global.dailyChallenge.pressure !== 'undefined') {
 		game.global.soldierHealthMax *= dailyModifiers.pressure.getMult(game.global.dailyChallenge.pressure.strength, game.global.dailyChallenge.pressure.stacks);
-
+	}
 	if (game.global.formation !== 0){
 		game.global.soldierHealthMax *= (game.global.formation == 1) ? 4 : 0.5;
 		game.global.soldierCurrentAttack *= (game.global.formation == 2) ? 4 : 0.5;

--- a/main.js
+++ b/main.js
@@ -2082,7 +2082,7 @@ function rewardResource(what, baseAmt, level, checkMapLootScale, givePercentage)
 				amt *= (1 + game.empowerments.Wind.getCombatModifier());
 			}
 		}
-		else 
+		else
 			amt *= (1 + (game.empowerments.Wind.getCombatModifier() * 10));
 	}
 	if (what == "helium"){
@@ -4209,7 +4209,7 @@ function handleIceDebuff() {
 		elem = document.getElementById('iceEmpowermentIcon');
 	}
 	elem.style.display = 'inline-block';
-	document.getElementById('iceEmpowermentText').innerHTML = prettify(game.empowerments.Ice.currentDebuffPower);	
+	document.getElementById('iceEmpowermentText').innerHTML = prettify(game.empowerments.Ice.currentDebuffPower);
 }
 
 function handleWindDebuff() {
@@ -4225,7 +4225,7 @@ function handleWindDebuff() {
 		elem = document.getElementById('windEmpowermentIcon');
 	}
 	elem.style.display = 'inline-block';
-	document.getElementById('windEmpowermentText').innerHTML = prettify(game.empowerments.Wind.currentDebuffPower);	
+	document.getElementById('windEmpowermentText').innerHTML = prettify(game.empowerments.Wind.currentDebuffPower);
 }
 
 function setEmpowerTab(){
@@ -6173,36 +6173,8 @@ function startFight() {
 		}
     }
     swapClass("cellColor", "cellColorCurrent", cellElem);
-	var badName;
-	var displayedName = (cell.name == "Improbability" && game.global.spireActive) ? "Druopitee" : cell.name.replace('_', ' ');
-	if (displayedName == "Mutimp" || displayedName == "Hulking Mutimp"){
-		displayedName = "<span class='Mutimp'>" + displayedName + "</span>";
-	}
-	if (cell.mutation) {
-		badName = "<span class='badNameMutation " + cell.mutation + "'>" + mutations[cell.mutation].namePrefix + " " + displayedName + "</span>";
-	}
-	else
-		badName = displayedName;
-	if (cell.empowerment){
-		badName = getEmpowerment(-1, true) + " " + badName;
-		badName = "<span class='badName" + getEmpowerment(-1) + "'>" + badName + "</span>"; 
-	}
-	if (game.global.challengeActive == "Coordinate"){
-		badCoord = getBadCoordLevel();
-		badName += " (" + prettify(badCoord) + ")";
-	}
-	if (cell.name == "Omnipotrimp" && game.global.world % 5 == 0){
-		badName += ' <span class="badge badBadge Magma" onmouseover="tooltip(\'Superheated\', \'customText\', event, \'This Omnipotrimp is Superheated, and will explode on death.\')" onmouseout="tooltip(\'hide\')"><span class="icomoon icon-fire2"></span></span>';
-	}
-	if (game.global.brokenPlanet && !game.global.mapsActive){
-		badName += ' <span class="badge badBadge" onmouseover="tooltip(\'Pierce\', \'customText\', event, \'' + prettify(getPierceAmt() * 100) + '% of the damage from this Bad Guy pierces through block\')" onmouseout="tooltip(\'hide\')"><span class="glyphicon glyphicon-tint"></span></span>';
-	}
-	if (game.global.challengeActive == "Slow" || ((game.badGuys[cell.name].fast || cell.mutation == "Corruption") && game.global.challengeActive != "Coordinate" && game.global.challengeActive != "Nom"))
-		badName += ' <span class="badge badBadge" onmouseover="tooltip(\'Fast\', \'customText\', event, \'This Bad Guy is fast and attacks first\')" onmouseout="tooltip(\'hide\')"><span class="glyphicon glyphicon-forward"></span></span>';
-	if ((game.global.challengeActive == "Electricity" || game.global.challengeActive == "Mapocalypse")){
-		badName += ' <span class="badge badBadge" onmouseover="tooltip(\'Electric\', \'customText\', event, \'This Bad Guy is electric and stacks a debuff on your Trimps\')" onmouseout="tooltip(\'hide\')"><span class="icomoon icon-power-cord"></span></span>';
-	}
-	document.getElementById("badGuyName").innerHTML = badName;
+
+	document.getElementById("badGuyName").innerHTML = getBadName();
 	var corruptionStart = mutations.Corruption.start(true);
 	if (cell.mutation)
 		setMutationTooltip(cell.corrupted, cell.mutation);
@@ -6490,6 +6462,44 @@ function startFight() {
 	if (instaFight) fight();
 }
 /**
+ * Generates the HTML for the bad guy, pulls info from cell and globals
+ * @param  {Cell} cell Cell the bad guy is in.
+ * @return {HTMLString}      HTMLString to show bad guy
+ */
+function getBadName(cell) {
+	var displayedName = (cell.name == "Improbability" && game.global.spireActive) ? "Druopitee" : cell.name.replace('_', ' ');
+	if (displayedName == "Mutimp" || displayedName == "Hulking Mutimp"){
+		displayedName = "<span class='Mutimp'>" + displayedName + "</span>";
+	}
+	var badName;
+	if (cell.mutation) {
+		badName = "<span class='badNameMutation " + cell.mutation + "'>" + mutations[cell.mutation].namePrefix + " " + displayedName + "</span>";
+	}
+	else
+		badName = displayedName;
+	if (cell.empowerment){
+		badName = getEmpowerment(-1, true) + " " + badName;
+		badName = "<span class='badName" + getEmpowerment(-1) + "'>" + badName + "</span>";
+	}
+	if (game.global.challengeActive == "Coordinate"){
+		var badCoord = getBadCoordLevel();
+		badName += " (" + prettify(badCoord) + ")";
+	}
+	if (cell.name == "Omnipotrimp" && game.global.world % 5 == 0){
+		badName += ' <span class="badge badBadge Magma" onmouseover="tooltip(\'Superheated\', \'customText\', event, \'This Omnipotrimp is Superheated, and will explode on death.\')" onmouseout="tooltip(\'hide\')"><span class="icomoon icon-fire2"></span></span>';
+	}
+	if (game.global.brokenPlanet && !game.global.mapsActive){
+		badName += ' <span class="badge badBadge" onmouseover="tooltip(\'Pierce\', \'customText\', event, \'' + prettify(getPierceAmt() * 100) + '% of the damage from this Bad Guy pierces through block\')" onmouseout="tooltip(\'hide\')"><span class="glyphicon glyphicon-tint"></span></span>';
+	}
+	if (game.global.challengeActive == "Slow" || ((game.badGuys[cell.name].fast || cell.mutation == "Corruption") && game.global.challengeActive != "Coordinate" && game.global.challengeActive != "Nom"))
+		badName += ' <span class="badge badBadge" onmouseover="tooltip(\'Fast\', \'customText\', event, \'This Bad Guy is fast and attacks first\')" onmouseout="tooltip(\'hide\')"><span class="glyphicon glyphicon-forward"></span></span>';
+	if ((game.global.challengeActive == "Electricity" || game.global.challengeActive == "Mapocalypse")){
+		badName += ' <span class="badge badBadge" onmouseover="tooltip(\'Electric\', \'customText\', event, \'This Bad Guy is electric and stacks a debuff on your Trimps\')" onmouseout="tooltip(\'hide\')"><span class="icomoon icon-power-cord"></span></span>';
+	}
+	return badName;
+}
+
+/**
  * Handles when cellElem == null, and brings game back into defined state
  */
 function cellElemNullError() {
@@ -6631,7 +6641,7 @@ function calculateDamage(number, buildString, isTrimp, noCheckAchieve, cell) { /
 				number *= dailyModifiers.rampage.getMult(game.global.dailyChallenge.rampage.strength, game.global.dailyChallenge.rampage.stacks);
 			}
 		}
-		
+
 
 	}
 	else {
@@ -8288,7 +8298,7 @@ function fight(makeUp) {
 		}
 		//Post Loot
 		resetEmpowerStacks();
-		
+
 		//Map and World split here for non-loot stuff, anything for both goes above
 		//Map Only
         if (game.global.mapsActive && cellNum == (game.global.mapGridArray.length - 1)) {

--- a/main.js
+++ b/main.js
@@ -6204,7 +6204,7 @@ function startFight() {
     }
 
     var trimpsFighting = game.resources.trimps.maxSoldiers;
-	var soldType = (game.portal.Coordinated.level) ? game.portal.Coordinated.currentSend: game.resources.trimps.maxSoldiers;
+	var soldierNum = (game.portal.Coordinated.level) ? game.portal.Coordinated.currentSend: game.resources.trimps.maxSoldiers;
     if (game.global.soldierHealth <= 0) {
 		spawnTrimps();
     }
@@ -6258,10 +6258,10 @@ function startFight() {
 			game.global.soldierCurrentBlock += blockTemp;
 			game.global.difs.block = 0;
 		}
-		if (game.resources.trimps.soldiers != soldType && game.global.maxSoldiersAtStart > 0){
+		if (game.resources.trimps.soldiers != soldierNum && game.global.maxSoldiersAtStart > 0){
 			var freeTrimps = (game.resources.trimps.owned - game.resources.trimps.employed);
 			var newTrimps = ((game.resources.trimps.maxSoldiers - game.global.maxSoldiersAtStart)  / game.global.maxSoldiersAtStart) + 1;
-			var requiredTrimps = (soldType - game.resources.trimps.soldiers);
+			var requiredTrimps = (soldierNum - game.resources.trimps.soldiers);
 			if (freeTrimps >= requiredTrimps) {
 				game.resources.trimps.owned -= requiredTrimps;
 				var oldHealth = game.global.soldierHealthMax;
@@ -6269,13 +6269,13 @@ function startFight() {
 				game.global.soldierHealth += (game.global.soldierHealthMax - oldHealth);
 				game.global.soldierCurrentAttack *= newTrimps;
 				game.global.soldierCurrentBlock *= newTrimps;
-				game.resources.trimps.soldiers = soldType;
+				game.resources.trimps.soldiers = soldierNum;
 				game.global.maxSoldiersAtStart = game.resources.trimps.maxSoldiers;
 			}
 		}
 	}
 
-	updateAllBattleNumbers(game.resources.trimps.soldiers < soldType);
+	updateAllBattleNumbers(game.resources.trimps.soldiers < soldierNum);
     game.global.fighting = true;
     game.global.lastFightUpdate = new Date();
 	if (instaFight) fight();

--- a/main.js
+++ b/main.js
@@ -6231,10 +6231,10 @@ cellElemNullError: function cellElemNullError() {
 /**
  * Sets the contents of '#corruptionBuff', from inputs & globals
  * @param {Cell} cell            Cell the bad guy is in
- * @param {Number} corruptionStart Zone where corruption starts
  * @param {Object} [map]             Map the cell is in
  */
-setCorruptionBuffUI: function setCorruptionBuffUI(cell, corruptionStart, map) {
+setCorruptionBuffUI: function setCorruptionBuffUI(cell, map) {
+	var corruptionStart = mutations.Corruption.start(true);
 	if (cell.mutation) {
 		setMutationTooltip(cell.corrupted, cell.mutation);
 	} else if (map && map.location == "Void" && game.global.world >= corruptionStart){
@@ -6416,7 +6416,6 @@ applyBadGuyImprobability: function applyBadGuyImprobability(cell) {
  */
 spawnSoldiers: function spawnSoldiers() {
 	var trimpsFighting = game.resources.trimps.maxSoldiers;
-	var soldierNum = (game.portal.Coordinated.level) ? game.portal.Coordinated.currentSend: game.resources.trimps.maxSoldiers;
 	lastSoldierSentAt = new Date().getTime();
 	game.global.battleCounter = 0;
 	if (game.portal.Anticipation.level){
@@ -6523,7 +6522,6 @@ spawnSoldiers: function spawnSoldiers() {
 handleStatChanges: function handleStatChanges() {
 	//Check differences in equipment, apply perks, bonuses, and formation
 	var trimpsFighting = game.resources.trimps.maxSoldiers;
-	var soldierNum = (game.portal.Coordinated.level) ? game.portal.Coordinated.currentSend: game.resources.trimps.maxSoldiers;
 	if (game.global.difs.health !== 0) {
 		var healthTemp = trimpsFighting * game.global.difs.health * ((game.portal.Toughness.modifier * game.portal.Toughness.level) + 1);
 		if (mutations.Magma.active()){
@@ -6570,6 +6568,7 @@ handleStatChanges: function handleStatChanges() {
 		game.global.soldierCurrentBlock += blockTemp;
 		game.global.difs.block = 0;
 	}
+	var soldierNum = fightNS.soldierNum;
 	if (game.resources.trimps.soldiers != soldierNum && game.global.maxSoldiersAtStart > 0){
 		var freeTrimps = (game.resources.trimps.owned - game.resources.trimps.employed);
 		var newTrimps = ((game.resources.trimps.maxSoldiers - game.global.maxSoldiersAtStart)  / game.global.maxSoldiersAtStart) + 1;
@@ -6586,6 +6585,11 @@ handleStatChanges: function handleStatChanges() {
 		}
 	}
 },
+
+get soldierNum() {
+	return (game.portal.Coordinated.level) ? game.portal.Coordinated.currentSend: game.resources.trimps.maxSoldiers;
+},
+
 };
 
 var lastSoldierSentAt =  new Date().getTime();
@@ -6614,7 +6618,7 @@ function startFight() {
 
 	document.getElementById("badGuyName").innerHTML = fightNS.getBadName(cell);
 	var corruptionStart = mutations.Corruption.start(true);
-	fightNS.setCorruptionBuffUI(cell, corruptionStart, map);
+	fightNS.setCorruptionBuffUI(cell, map);
 
 	if (game.global.challengeActive == "Balance") updateBalanceStacks();
 	if (game.global.challengeActive == "Toxicity") updateToxicityStacks();
@@ -6627,7 +6631,6 @@ function startFight() {
     }
 
     var trimpsFighting = game.resources.trimps.maxSoldiers;
-	var soldierNum = (game.portal.Coordinated.level) ? game.portal.Coordinated.currentSend: game.resources.trimps.maxSoldiers;
     if (game.global.soldierHealth <= 0) {
 		//TODO: move this into fight
 		if (cell.name == "Voidsnimp" && !game.achievements.oneOffs.finished[2]) {
@@ -6646,7 +6649,7 @@ function startFight() {
 		fightNS.handleStatChanges();
 	}
 
-	updateAllBattleNumbers(game.resources.trimps.soldiers < soldierNum);
+	updateAllBattleNumbers(game.resources.trimps.soldiers < fightNS.soldierNum);
     game.global.fighting = true;
     game.global.lastFightUpdate = new Date();
 	if (instaFight) fight();

--- a/main.js
+++ b/main.js
@@ -6206,6 +6206,16 @@ function startFight() {
     var trimpsFighting = game.resources.trimps.maxSoldiers;
 	var soldierNum = (game.portal.Coordinated.level) ? game.portal.Coordinated.currentSend: game.resources.trimps.maxSoldiers;
     if (game.global.soldierHealth <= 0) {
+		//TODO: move this into fight
+		if (cell.name == "Voidsnimp" && !game.achievements.oneOffs.finished[2]) {
+			if (!cell.killCount) {
+				cell.killCount = 1;
+			} else {
+				cell.killCount++;
+			}
+			if (cell.killCount >= 50) giveSingleAchieve(2);
+		}
+
 		spawnTrimps();
     }
 	else {
@@ -6465,14 +6475,6 @@ function spawnTrimps() {
 	var soldierNum = (game.portal.Coordinated.level) ? game.portal.Coordinated.currentSend: game.resources.trimps.maxSoldiers;
 	lastSoldierSentAt = new Date().getTime();
 	game.global.battleCounter = 0;
-	if (cell.name == "Voidsnimp" && !game.achievements.oneOffs.finished[2]) {
-		if (!cell.killCount) {
-			cell.killCount = 1;
-		} else {
-			cell.killCount++;
-		}
-		if (cell.killCount >= 50) giveSingleAchieve(2);
-	}
 	if (game.portal.Anticipation.level){
 		game.global.antiStacks = Math.floor(game.global.lastBreedTime / 1000);
 		if (game.global.antiStacks >= 30) game.global.antiStacks = 30;

--- a/main.js
+++ b/main.js
@@ -21,6 +21,22 @@
 		<trimps.github.io/license.txt>). If not, see
 		<http://www.gnu.org/licenses/>. */
 "use strict";
+/**
+ * String containing HTML
+ * @typedef {String} HTMLString
+ */
+/**
+* Object representing a cell in a map/zone
+* @typedef {Object} Cell
+* @property {Number} level Cell number in zone/map. Starts at 1
+* @property {Number} maxHealth Negatives are flags that the bad guy needs to be spawned
+* @property {Number} health
+* @property {Number} attack
+* @property {String} special
+* @property {String} text
+* @property {String} name
+* @property {Number} [killCount]
+*/
 if (typeof kongregate === 'undefined' && document.getElementById("boneBtn") !== null) {
 	var boneBtn = document.getElementById("getBonesBtn");
 	boneBtn.onclick = "";

--- a/main.js
+++ b/main.js
@@ -6154,7 +6154,6 @@ function startFight() {
     var cellNum;
     var cell;
     var cellElem;
-	var badCoord;
 	var instaFight = false;
 	var madeBadGuy = false;
 	var map = false;
@@ -6176,16 +6175,7 @@ function startFight() {
 
 	document.getElementById("badGuyName").innerHTML = getBadName();
 	var corruptionStart = mutations.Corruption.start(true);
-	if (cell.mutation)
-		setMutationTooltip(cell.corrupted, cell.mutation);
-	else if (map && map.location == "Void" && game.global.world >= corruptionStart){
-		setVoidCorruptionIcon();
-	}
-	else if (map && mutations.Magma.active()){
-		setVoidCorruptionIcon(true);
-	}
-	else
-		document.getElementById('corruptionBuff').innerHTML = "";
+	setCorruptionBuffUI(cell, map, corruptionStart);
 	if (game.global.challengeActive == "Balance") updateBalanceStacks();
 	if (game.global.challengeActive == "Toxicity") updateToxicityStacks();
     if (cell.maxHealth == -1) {
@@ -6520,6 +6510,23 @@ function cellElemNullError() {
 	return;
 }
 
+/**
+ * Sets the contents of '#corruptionBuff', from inputs & globals
+ * @param {Cell} cell            Cell the bad guy is in
+ * @param {Object} map             Map the cell is in
+ * @param {Number} corruptionStart Zone where corruption starts
+ */
+function setCorruptionBuffUI(cell, map, corruptionStart) {
+	if (cell.mutation) {
+		setMutationTooltip(cell.corrupted, cell.mutation);
+	} else if (map && map.location == "Void" && game.global.world >= corruptionStart){
+		setVoidCorruptionIcon();
+	} else if (map && mutations.Magma.active()){
+		setVoidCorruptionIcon(true);
+	} else {
+		document.getElementById('corruptionBuff').innerHTML = "";
+	}
+}
 function updateAllBattleNumbers (skipNum) {
 	var cellNum;
     var cell;

--- a/main.js
+++ b/main.js
@@ -30,12 +30,16 @@
 * @typedef {Object} Cell
 * @property {Number} level Cell number in zone/map. Starts at 1
 * @property {Number} maxHealth Negatives are flags that the bad guy needs to be spawned
-* @property {Number} health
+* @property {Number} health Health of the cell, negatives are flags for needs spawning
 * @property {Number} attack
-* @property {String} special
-* @property {String} text
-* @property {String} name
-* @property {Number} [killCount]
+* @property {String} special Loot ocated in the cell, e.g. freeMetals
+* @property {String} text HTMLString to show in cell
+* @property {String} name Name of bad guy
+* @property {Number} [killCount] Number of kills the cell has gotten as a voidsnimp
+* @property {Number} [origAttack] Original attack before spire modifier
+* @property {Number} [origHealth] Original health before spire modifier
+* @property {String} [mutation] Mutation on cell, e.g. corruption, magma
+* @property {String} [corrupted] Type of corruption the cell has
 */
 if (typeof kongregate === 'undefined' && document.getElementById("boneBtn") !== null) {
 	var boneBtn = document.getElementById("getBonesBtn");

--- a/main.js
+++ b/main.js
@@ -6187,20 +6187,22 @@ function startFight() {
 			return;
 		}
     }
+
     swapClass("cellColor", "cellColorCurrent", cellElem);
 
-	document.getElementById("badGuyName").innerHTML = getBadName();
+	document.getElementById("badGuyName").innerHTML = getBadName(cell);
 	var corruptionStart = mutations.Corruption.start(true);
 	setCorruptionBuffUI(cell, map, corruptionStart);
+
 	if (game.global.challengeActive == "Balance") updateBalanceStacks();
 	if (game.global.challengeActive == "Toxicity") updateToxicityStacks();
+	if (game.global.challengeActive == "Nom" && cell.nomStacks) updateNomStacks(cell.nomStacks);
+
     if (cell.maxHealth == -1) {
 		instaFight = spawnBadGuy(cell);
 		madeBadGuy = true;
     }
-	else if (game.global.challengeActive == "Nom" && cell.nomStacks){
-		updateNomStacks(cell.nomStacks);
-	}
+
     var trimpsFighting = game.resources.trimps.maxSoldiers;
 	var soldType = (game.portal.Coordinated.level) ? game.portal.Coordinated.currentSend: game.resources.trimps.maxSoldiers;
     if (game.global.soldierHealth <= 0) {

--- a/main.js
+++ b/main.js
@@ -6218,69 +6218,7 @@ function startFight() {
     }
 	else {
 		if (game.global.challengeActive == "Lead") manageLeadStacks(!game.global.mapsActive && madeBadGuy);
-
-		//Check differences in equipment, apply perks, bonuses, and formation
-		if (game.global.difs.health !== 0) {
-			var healthTemp = trimpsFighting * game.global.difs.health * ((game.portal.Toughness.modifier * game.portal.Toughness.level) + 1);
-			if (mutations.Magma.active()){
-				healthTemp *= mutations.Magma.getTrimpDecay();
-			}
-			if (game.portal.Toughness_II.level) healthTemp *= (1 + (game.portal.Toughness_II.modifier * game.portal.Toughness_II.level));
-			if (game.jobs.Geneticist.owned > 0) healthTemp *= Math.pow(1.01, game.global.lastLowGen);
-			if (game.goldenUpgrades.Battle.currentBonus > 0) healthTemp *= game.goldenUpgrades.Battle.currentBonus + 1;
-			if (game.portal.Resilience.level > 0) healthTemp *= Math.pow(game.portal.Resilience.modifier + 1, game.portal.Resilience.level);
-		if (game.global.challengeActive == "Daily" && typeof game.global.dailyChallenge.pressure !== 'undefined') healthTemp *= dailyModifiers.pressure.getMult(game.global.dailyChallenge.pressure.strength, game.global.dailyChallenge.pressure.stacks);
-			if (game.global.formation !== 0){
-				healthTemp *= (game.global.formation == 1) ? 4 : 0.5;
-			}
-			if (game.global.totalSquaredReward > 0)
-				healthTemp *= ((game.global.totalSquaredReward / 100) + 1);
-			if (game.global.challengeActive == "Balance"){
-				healthTemp *= game.challenges.Balance.getHealthMult();
-			}
-			healthTemp = calcHeirloomBonus("Shield", "trimpHealth", healthTemp);
-			game.global.soldierHealthMax += healthTemp;
-			game.global.soldierHealth += healthTemp;
-			game.global.difs.health = 0;
-			if (game.global.soldierHealth <= 0) game.global.soldierHealth = 0;
-		}
-		if (game.global.difs.attack !== 0) {
-			var attackTemp = trimpsFighting * game.global.difs.attack * ((game.portal.Power.modifier * game.portal.Power.level) + 1);
-			if (mutations.Magma.active()){
-				attackTemp *= mutations.Magma.getTrimpDecay();
-			}
-			if (game.portal.Power_II.level) attackTemp *= (1 + (game.portal.Power_II.modifier * game.portal.Power_II.level));
-			if (game.global.formation !== 0){
-				attackTemp *= (game.global.formation == 2) ? 4 : 0.5;
-			}
-			attackTemp = calcHeirloomBonus("Shield", "trimpAttack", attackTemp);
-			game.global.soldierCurrentAttack += attackTemp;
-			game.global.difs.attack = 0;
-		}
-		if (game.global.difs.block !== 0) {
-			var blockTemp = (trimpsFighting * game.global.difs.block * ((game.global.difs.trainers * (calcHeirloomBonus("Shield", "trainerEfficiency", game.jobs.Trainer.modifier) / 100)) + 1));
-			if (game.global.formation !== 0){
-				blockTemp *= (game.global.formation == 3) ? 4 : 0.5;
-			}
-			blockTemp = calcHeirloomBonus("Shield", "trimpBlock", blockTemp);
-			game.global.soldierCurrentBlock += blockTemp;
-			game.global.difs.block = 0;
-		}
-		if (game.resources.trimps.soldiers != soldierNum && game.global.maxSoldiersAtStart > 0){
-			var freeTrimps = (game.resources.trimps.owned - game.resources.trimps.employed);
-			var newTrimps = ((game.resources.trimps.maxSoldiers - game.global.maxSoldiersAtStart)  / game.global.maxSoldiersAtStart) + 1;
-			var requiredTrimps = (soldierNum - game.resources.trimps.soldiers);
-			if (freeTrimps >= requiredTrimps) {
-				game.resources.trimps.owned -= requiredTrimps;
-				var oldHealth = game.global.soldierHealthMax;
-				game.global.soldierHealthMax *= newTrimps;
-				game.global.soldierHealth += (game.global.soldierHealthMax - oldHealth);
-				game.global.soldierCurrentAttack *= newTrimps;
-				game.global.soldierCurrentBlock *= newTrimps;
-				game.resources.trimps.soldiers = soldierNum;
-				game.global.maxSoldiersAtStart = game.resources.trimps.maxSoldiers;
-			}
-		}
+		handleStatChanges();
 	}
 
 	updateAllBattleNumbers(game.resources.trimps.soldiers < soldierNum);
@@ -6572,6 +6510,77 @@ function spawnTrimps() {
 	}
 	if (game.global.challengeActive == "Lead") manageLeadStacks();
 
+}
+
+/**
+ * Apply changes to stats stored in game.global.difs
+ * @return {[type]} [description]
+ */
+function handleStatChanges() {
+	//Check differences in equipment, apply perks, bonuses, and formation
+	var trimpsFighting = game.resources.trimps.maxSoldiers;
+	var soldierNum = (game.portal.Coordinated.level) ? game.portal.Coordinated.currentSend: game.resources.trimps.maxSoldiers;
+	if (game.global.difs.health !== 0) {
+		var healthTemp = trimpsFighting * game.global.difs.health * ((game.portal.Toughness.modifier * game.portal.Toughness.level) + 1);
+		if (mutations.Magma.active()){
+			healthTemp *= mutations.Magma.getTrimpDecay();
+		}
+		if (game.portal.Toughness_II.level) healthTemp *= (1 + (game.portal.Toughness_II.modifier * game.portal.Toughness_II.level));
+		if (game.jobs.Geneticist.owned > 0) healthTemp *= Math.pow(1.01, game.global.lastLowGen);
+		if (game.goldenUpgrades.Battle.currentBonus > 0) healthTemp *= game.goldenUpgrades.Battle.currentBonus + 1;
+		if (game.portal.Resilience.level > 0) healthTemp *= Math.pow(game.portal.Resilience.modifier + 1, game.portal.Resilience.level);
+	if (game.global.challengeActive == "Daily" && typeof game.global.dailyChallenge.pressure !== 'undefined') healthTemp *= dailyModifiers.pressure.getMult(game.global.dailyChallenge.pressure.strength, game.global.dailyChallenge.pressure.stacks);
+		if (game.global.formation !== 0){
+			healthTemp *= (game.global.formation == 1) ? 4 : 0.5;
+		}
+		if (game.global.totalSquaredReward > 0)
+			healthTemp *= ((game.global.totalSquaredReward / 100) + 1);
+		if (game.global.challengeActive == "Balance"){
+			healthTemp *= game.challenges.Balance.getHealthMult();
+		}
+		healthTemp = calcHeirloomBonus("Shield", "trimpHealth", healthTemp);
+		game.global.soldierHealthMax += healthTemp;
+		game.global.soldierHealth += healthTemp;
+		game.global.difs.health = 0;
+		if (game.global.soldierHealth <= 0) game.global.soldierHealth = 0;
+	}
+	if (game.global.difs.attack !== 0) {
+		var attackTemp = trimpsFighting * game.global.difs.attack * ((game.portal.Power.modifier * game.portal.Power.level) + 1);
+		if (mutations.Magma.active()){
+			attackTemp *= mutations.Magma.getTrimpDecay();
+		}
+		if (game.portal.Power_II.level) attackTemp *= (1 + (game.portal.Power_II.modifier * game.portal.Power_II.level));
+		if (game.global.formation !== 0){
+			attackTemp *= (game.global.formation == 2) ? 4 : 0.5;
+		}
+		attackTemp = calcHeirloomBonus("Shield", "trimpAttack", attackTemp);
+		game.global.soldierCurrentAttack += attackTemp;
+		game.global.difs.attack = 0;
+	}
+	if (game.global.difs.block !== 0) {
+		var blockTemp = (trimpsFighting * game.global.difs.block * ((game.global.difs.trainers * (calcHeirloomBonus("Shield", "trainerEfficiency", game.jobs.Trainer.modifier) / 100)) + 1));
+		if (game.global.formation !== 0){
+			blockTemp *= (game.global.formation == 3) ? 4 : 0.5;
+		}
+		blockTemp = calcHeirloomBonus("Shield", "trimpBlock", blockTemp);
+		game.global.soldierCurrentBlock += blockTemp;
+		game.global.difs.block = 0;
+	}
+	if (game.resources.trimps.soldiers != soldierNum && game.global.maxSoldiersAtStart > 0){
+		var freeTrimps = (game.resources.trimps.owned - game.resources.trimps.employed);
+		var newTrimps = ((game.resources.trimps.maxSoldiers - game.global.maxSoldiersAtStart)  / game.global.maxSoldiersAtStart) + 1;
+		var requiredTrimps = (soldierNum - game.resources.trimps.soldiers);
+		if (freeTrimps >= requiredTrimps) {
+			game.resources.trimps.owned -= requiredTrimps;
+			var oldHealth = game.global.soldierHealthMax;
+			game.global.soldierHealthMax *= newTrimps;
+			game.global.soldierHealth += (game.global.soldierHealthMax - oldHealth);
+			game.global.soldierCurrentAttack *= newTrimps;
+			game.global.soldierCurrentBlock *= newTrimps;
+			game.resources.trimps.soldiers = soldierNum;
+			game.global.maxSoldiersAtStart = game.resources.trimps.maxSoldiers;
+		}
+	}
 }
 
 function updateAllBattleNumbers (skipNum) {

--- a/main.js
+++ b/main.js
@@ -6206,107 +6206,7 @@ function startFight() {
     var trimpsFighting = game.resources.trimps.maxSoldiers;
 	var soldType = (game.portal.Coordinated.level) ? game.portal.Coordinated.currentSend: game.resources.trimps.maxSoldiers;
     if (game.global.soldierHealth <= 0) {
-				lastSoldierSentAt = new Date().getTime();
-		game.global.battleCounter = 0;
-		if (cell.name == "Voidsnimp" && !game.achievements.oneOffs.finished[2]) {
-			if (!cell.killCount) cell.killCount = 1;
-			else cell.killCount++;
-			if (cell.killCount >= 50) giveSingleAchieve(2);
-		}
-		if (game.portal.Anticipation.level){
-			game.global.antiStacks = Math.floor(game.global.lastBreedTime / 1000);
-			if (game.global.antiStacks >= 30) game.global.antiStacks = 30;
-			game.global.lastBreedTime = 0;
-			updateAntiStacks();
-		}
-		if ((game.global.challengeActive == "Electricity" || game.global.challengeActive == "Mapocalypse")) {
-			game.global.radioStacks = 0;
-			updateRadioStacks();
-		}
-		if (game.global.challengeActive == "Daily"){
-			if (typeof game.global.dailyChallenge.plague !== 'undefined'){
-				game.global.dailyChallenge.plague.stacks = 0;
-				updateDailyStacks('plague');
-			}
-			if (typeof game.global.dailyChallenge.weakness !== 'undefined'){
-				game.global.dailyChallenge.weakness.stacks = 0;
-				updateDailyStacks('weakness');
-			}
-			if (typeof game.global.dailyChallenge.rampage !== 'undefined'){
-				game.global.dailyChallenge.rampage.stacks = 0;
-				updateDailyStacks('rampage');
-			}
-			if (!game.global.passive && typeof game.global.dailyChallenge.empower !== 'undefined'){
-				if (!game.global.mapsActive){
-					game.global.dailyChallenge.empower.stacks += dailyModifiers.empower.stacksToAdd(game.global.dailyChallenge.empower.strength);
-					var maxStack = dailyModifiers.empower.getMaxStacks(game.global.dailyChallenge.empower.strength);
-					if (game.global.dailyChallenge.empower.stacks >= maxStack) game.global.dailyChallenge.empower.stacks = maxStack;
-				}
-				updateDailyStacks('empower');
-			}
-		}
-		game.global.difs.attack = 0;
-		game.global.difs.health = 0;
-		game.global.difs.block = 0;
-		game.global.difs.trainers = game.jobs.Trainer.owned;
-        game.global.soldierHealthMax = game.global.health;
-		game.global.maxSoldiersAtStart = game.resources.trimps.maxSoldiers;
-        game.global.soldierCurrentAttack = game.global.attack;
-		//Magma;
-		if (mutations.Magma.active()){
-			var magMult = mutations.Magma.getTrimpDecay();
-			game.global.soldierHealthMax *= magMult;
-			game.global.soldierCurrentAttack *= magMult;
-		}
-		//Soldiers
-		game.global.soldierHealthMax *= trimpsFighting;
-		game.global.soldierCurrentAttack *= trimpsFighting;
-		//Toughness
-		if (game.portal.Toughness.level > 0) game.global.soldierHealthMax += (game.global.soldierHealthMax * game.portal.Toughness.level * game.portal.Toughness.modifier);
-		if (game.portal.Toughness_II.level > 0) game.global.soldierHealthMax *= (1 + (game.portal.Toughness_II.modifier * game.portal.Toughness_II.level));
-		if (game.global.lowestGen >= 0) {
-			if (game.global.breedBack <= 0) {
-				game.global.soldierHealthMax *= Math.pow(1.01, game.global.lowestGen);
-				game.global.lastLowGen = game.global.lowestGen;
-				game.global.lowestGen = -1;
-			}
-			else game.global.lastLowGen = 0;
-			game.global.breedBack = soldType / 2;
-		}
-		if (game.goldenUpgrades.Battle.currentBonus > 0){
-			game.global.soldierHealthMax *= game.goldenUpgrades.Battle.currentBonus + 1;
-		}
-		//Resilience
-		if (game.portal.Resilience.level > 0) game.global.soldierHealthMax *= Math.pow(game.portal.Resilience.modifier + 1, game.portal.Resilience.level);
-		//Power
-		if (game.portal.Power.level > 0) game.global.soldierCurrentAttack += (game.global.soldierCurrentAttack * game.portal.Power.level * game.portal.Power.modifier);
-        if (game.portal.Power_II.level > 0) game.global.soldierCurrentAttack *= (1 + (game.portal.Power_II.modifier * game.portal.Power_II.level));
-		game.global.soldierCurrentBlock = Math.floor((game.global.block * (game.jobs.Trainer.owned * (calcHeirloomBonus("Shield", "trainerEfficiency", game.jobs.Trainer.modifier) / 100)) + game.global.block) * trimpsFighting);
-		game.global.soldierHealthMax = calcHeirloomBonus("Shield", "trimpHealth", game.global.soldierHealthMax);
-		game.global.soldierCurrentAttack = calcHeirloomBonus("Shield", "trimpAttack", game.global.soldierCurrentAttack);
-		game.global.soldierCurrentBlock = calcHeirloomBonus("Shield", "trimpBlock", game.global.soldierCurrentBlock);
-		if (game.global.challengeActive == "Daily" && typeof game.global.dailyChallenge.pressure !== 'undefined') game.global.soldierHealthMax *= dailyModifiers.pressure.getMult(game.global.dailyChallenge.pressure.strength, game.global.dailyChallenge.pressure.stacks);
-		if (game.global.formation !== 0){
-			game.global.soldierHealthMax *= (game.global.formation == 1) ? 4 : 0.5;
-			game.global.soldierCurrentAttack *= (game.global.formation == 2) ? 4 : 0.5;
-			game.global.soldierCurrentBlock *= (game.global.formation == 3) ? 4 : 0.5;
-		}
-		if (game.global.challengeActive == "Balance"){
-			game.global.soldierHealthMax *= game.challenges.Balance.getHealthMult();
-		}
-		if (game.talents.voidPower.purchased && game.global.voidBuff){
-			var vpAmt = (game.talents.voidPower2.purchased) ? 35 : 15;
-			game.global.soldierHealthMax *= ((vpAmt / 100) + 1);
-		}
-		if (game.global.totalSquaredReward > 0)
-			game.global.soldierHealthMax *= ((game.global.totalSquaredReward / 100) + 1);
-		game.global.soldierHealth = game.global.soldierHealthMax;
-		if (game.global.challengeActive == "Devastation") {
-			if (game.challenges.Devastation.lastOverkill != -1) game.global.soldierHealth -= (game.challenges.Devastation.lastOverkill * 7.5);
-			game.challenges.Devastation.lastOverkill = -1;
-			if (game.global.soldierHealth < 1) game.global.soldierHealth = 0;
-		}
-		if (game.global.challengeActive == "Lead") manageLeadStacks();
+		spawnTrimps();
     }
 	else {
 		if (game.global.challengeActive == "Lead") manageLeadStacks(!game.global.mapsActive && madeBadGuy);
@@ -6558,6 +6458,117 @@ function spawnBadGuy(cell) {
 		game.global.waitToScry = false;
 	}
 	return instaFight;
+}
+
+function spawnTrimps() {
+	var trimpsFighting = game.resources.trimps.maxSoldiers;
+	var soldierNum = (game.portal.Coordinated.level) ? game.portal.Coordinated.currentSend: game.resources.trimps.maxSoldiers;
+	lastSoldierSentAt = new Date().getTime();
+	game.global.battleCounter = 0;
+	if (cell.name == "Voidsnimp" && !game.achievements.oneOffs.finished[2]) {
+		if (!cell.killCount) {
+			cell.killCount = 1;
+		} else {
+			cell.killCount++;
+		}
+		if (cell.killCount >= 50) giveSingleAchieve(2);
+	}
+	if (game.portal.Anticipation.level){
+		game.global.antiStacks = Math.floor(game.global.lastBreedTime / 1000);
+		if (game.global.antiStacks >= 30) game.global.antiStacks = 30;
+		game.global.lastBreedTime = 0;
+		updateAntiStacks();
+	}
+	if ((game.global.challengeActive == "Electricity" || game.global.challengeActive == "Mapocalypse")) {
+		game.challenges.Electricity.stacks = 0;
+		updateElectricityStacks();
+	}
+	if (game.global.challengeActive == "Daily"){
+		var dailyChallenges = ['plague', 'weakness', 'rampage'];
+		// This is why ES6 i of array exists.
+		for (var i = 0; i < dailyChallenges.length; i++) {
+			if (game.global.dailyChallenge[dailyChallenges[i]]) {
+				game.global.dailyChallenge[dailyChallenges[i]].stacks = 0;
+			}
+			updateDailyStacks(dailyChallenges[i]);
+		}
+
+		if (!game.global.passive && typeof game.global.dailyChallenge.empower !== 'undefined'){
+			if (!game.global.mapsActive){
+				game.global.dailyChallenge.empower.stacks += dailyModifiers.empower.stacksToAdd(game.global.dailyChallenge.empower.strength);
+				var maxStack = dailyModifiers.empower.getMaxStacks(game.global.dailyChallenge.empower.strength);
+				if (game.global.dailyChallenge.empower.stacks >= maxStack) game.global.dailyChallenge.empower.stacks = maxStack;
+			}
+			updateDailyStacks('empower');
+		}
+	}
+	game.global.difs.attack = 0;
+	game.global.difs.health = 0;
+	game.global.difs.block = 0;
+	game.global.difs.trainers = game.jobs.Trainer.owned;
+	game.global.soldierHealthMax = game.global.health;
+	game.global.maxSoldiersAtStart = game.resources.trimps.maxSoldiers;
+	game.global.soldierCurrentAttack = game.global.attack;
+	//Magma;
+	if (mutations.Magma.active()){
+		var magMult = mutations.Magma.getTrimpDecay();
+		game.global.soldierHealthMax *= magMult;
+		game.global.soldierCurrentAttack *= magMult;
+	}
+	//Soldiers
+	game.global.soldierHealthMax *= trimpsFighting;
+	game.global.soldierCurrentAttack *= trimpsFighting;
+	//Toughness
+	if (game.portal.Toughness.level > 0) game.global.soldierHealthMax += (game.global.soldierHealthMax * game.portal.Toughness.level * game.portal.Toughness.modifier);
+	if (game.portal.Toughness_II.level > 0) game.global.soldierHealthMax *= (1 + (game.portal.Toughness_II.modifier * game.portal.Toughness_II.level));
+	if (game.global.lowestGen >= 0) {
+		if (game.global.breedBack <= 0) {
+			game.global.soldierHealthMax *= Math.pow(1.01, game.global.lowestGen);
+			game.global.lastLowGen = game.global.lowestGen;
+			game.global.lowestGen = -1;
+		} else {
+			game.global.lastLowGen = 0;
+		}
+		game.global.breedBack = soldierNum / 2;
+	}
+	if (game.goldenUpgrades.Battle.currentBonus > 0){
+		game.global.soldierHealthMax *= game.goldenUpgrades.Battle.currentBonus + 1;
+	}
+	//Resilience
+	if (game.portal.Resilience.level > 0) game.global.soldierHealthMax *= Math.pow(game.portal.Resilience.modifier + 1, game.portal.Resilience.level);
+	//Power
+	if (game.portal.Power.level > 0) game.global.soldierCurrentAttack += (game.global.soldierCurrentAttack * game.portal.Power.level * game.portal.Power.modifier);
+	if (game.portal.Power_II.level > 0) game.global.soldierCurrentAttack *= (1 + (game.portal.Power_II.modifier * game.portal.Power_II.level));
+	game.global.soldierCurrentBlock = Math.floor((game.global.block * (game.jobs.Trainer.owned * (calcHeirloomBonus("Shield", "trainerEfficiency", game.jobs.Trainer.modifier) / 100)) + game.global.block) * trimpsFighting);
+	game.global.soldierHealthMax = calcHeirloomBonus("Shield", "trimpHealth", game.global.soldierHealthMax);
+	game.global.soldierCurrentAttack = calcHeirloomBonus("Shield", "trimpAttack", game.global.soldierCurrentAttack);
+	game.global.soldierCurrentBlock = calcHeirloomBonus("Shield", "trimpBlock", game.global.soldierCurrentBlock);
+	if (game.global.challengeActive == "Daily" && typeof game.global.dailyChallenge.pressure !== 'undefined') {
+		game.global.soldierHealthMax *= dailyModifiers.pressure.getMult(game.global.dailyChallenge.pressure.strength, game.global.dailyChallenge.pressure.stacks);
+
+	if (game.global.formation !== 0){
+		game.global.soldierHealthMax *= (game.global.formation == 1) ? 4 : 0.5;
+		game.global.soldierCurrentAttack *= (game.global.formation == 2) ? 4 : 0.5;
+		game.global.soldierCurrentBlock *= (game.global.formation == 3) ? 4 : 0.5;
+	}
+	if (game.global.challengeActive == "Balance"){
+		game.global.soldierHealthMax *= game.challenges.Balance.getHealthMult();
+	}
+	if (game.talents.voidPower.purchased && game.global.voidBuff){
+		var vpAmt = (game.talents.voidPower2.purchased) ? 35 : 15;
+		game.global.soldierHealthMax *= ((vpAmt / 100) + 1);
+	}
+	if (game.global.totalSquaredReward > 0) {
+		game.global.soldierHealthMax *= ((game.global.totalSquaredReward / 100) + 1);
+	}
+	game.global.soldierHealth = game.global.soldierHealthMax;
+	if (game.global.challengeActive == "Devastation") {
+		if (game.challenges.Devastation.lastOverkill != -1) game.global.soldierHealth -= (game.challenges.Devastation.lastOverkill * 7.5);
+		game.challenges.Devastation.lastOverkill = -1;
+		if (game.global.soldierHealth < 1) game.global.soldierHealth = 0;
+	}
+	if (game.global.challengeActive == "Lead") manageLeadStacks();
+
 }
 
 function updateAllBattleNumbers (skipNum) {

--- a/main.js
+++ b/main.js
@@ -6585,7 +6585,6 @@ applySoldierToughness: function applySoldierToughness() {
 
 /**
  * Applies geneticist bonus and sets up next geneticist
- * @return {[type]} [description]
  */
 applySoldierGeneticist: function applySoldierGeneticist() {
 	if (game.global.lowestGen >= 0) {
@@ -6658,7 +6657,6 @@ applySoldierFormation: function applySoldierFormation() {
 
 /**
  * Applies balance mutator
- * @return {[type]} [description]
  */
 applySoldierBalance: function applySoldierBalance() {
 	if (game.global.challengeActive == "Balance"){

--- a/main.js
+++ b/main.js
@@ -6283,14 +6283,18 @@ spawnBadGuy: function spawnBadGuy(cell, map) {
 },
 
 /**
- * Applies mutation to a newly spawned bad guy
+ * Sets attack and health of bad guy, and applies mutation to a newly spawned bad guy
  * @param  {Cell} cell Cell to apply mutation to
  */
 applyBadGuyMutation: function applyBadGuyMutation(cell) {
-	if (cell.mutation && typeof mutations[cell.mutation].health !== 'undefined') {
-		cell.health = mutations[cell.mutation].health(cell.level, cell.name);
-	} else {
-		cell.health = game.global.getEnemyHealth(cell.level, cell.name);
+	var stats = ['attack', 'health'];
+	var getEnemy = ['getEnemyAttack', 'getEnemyAttack'];
+	for (var i = 0; i < stats.length; i++) {
+		if (cell.mutation && typeof mutations[cell.mutation][stats[i]] !== 'undefined') {
+			cell[stats[i]] = mutations[cell.mutation][stats[i]](cell.level, cell.name);
+		} else {
+			cell[stats[i]] = game.global[getEnemy[i]](cell.level, cell.name);
+		}
 	}
 },
 
@@ -6485,7 +6489,7 @@ applySoldierChallenges: function applySoldierChallenges() {
 updateSoldierAnticipation: function updateSoldierAnticipation() {
 	if (game.portal.Anticipation.level){
 		game.global.antiStacks = Math.floor(game.global.lastBreedTime / 1000);
-		if (game.global.antiSgame.global.antiStackstacks >= 30) {
+		if (game.global.antiStackstacks >= 30) {
 			game.global.antiStacks = 30;
 		}
 		game.global.lastBreedTime = 0;
@@ -6541,7 +6545,7 @@ updateSoldierEmpower: function updateSoldierEmpower() {
 /**
  * Reset global.difs and soldier attack, health and block
  */
-resetSoliderStats: function resetSoliderStats() {
+resetSoldierStats: function resetSoldierStats() {
 	game.global.battleCounter = 0;
 	game.global.difs.attack = 0;
 	game.global.difs.health = 0;
@@ -6887,7 +6891,7 @@ function startFight() {
 	document.getElementById("badGuyName").innerHTML = fightNS.getBadName(cell);
 	var corruptionStart = mutations.Corruption.start(true);
 	fightNS.setCorruptionBuffUI(cell, map);
-	fightNS.updateStartFightChallenges();
+	fightNS.updateStartFightChallenges(cell);
 
 	var instaFight;
     if (cell.maxHealth == -1) {

--- a/updates.js
+++ b/updates.js
@@ -92,7 +92,7 @@ function tooltip(what, isItIn, event, textString, attachFunction, numCheck, rena
 		var lvlsLeft = ((5 - (game.global.world % 5)) + game.global.world) + 1;
 		tooltipText = "<p>The " + active + " Empowerment is currently active!</p><p>" + emp.description() + "</p><p>This Empowerment will end on Z" + lvlsLeft + ", at which point you'll be able to fight a " + getEmpowerment(null, true) + " enemy to earn a Token of " + active + ".</p>";
 		costText = "";
-		
+
 	}
 	if (what == "Finish Daily"){
 		var value = getDailyHeliumValue(countDailyWeight()) / 100;


### PR DESCRIPTION
Startfight has been broken down into seven functions, cellElemNullError, getBadName, setCorruptionBuffUI, updateStartFightChallenges, spawnBadGuy, spawnSoldiers and handleStatChanges.

You can now read startfight from top to bottom and understand what's happening without having to reread the function multiple times.