### PR TITLE
Update tab title to show number of alerts.

### DIFF
--- a/main.js
+++ b/main.js
@@ -10426,6 +10426,15 @@ function updatePortalTimer(justGetTime) {
 	setTimeout(updatePortalTimer, 1000);
 }
 
+var title = document.title;
+function changeTitle() {
+    if (!game.options.menu.showAlerts.enabled) {document.title=title; return;}
+	var alerts = document.getElementById('buyContainer').getElementsByClassName('alert badge');
+	var upgrades = Array.prototype.filter.call(alerts, function(tt){ return tt.innerHTML === '!'}).length;
+	document.title = '(' + upgrades + ') ' + title
+}
+setInterval(changeTitle, 2000);
+
 var shiftPressed = false;
 var ctrlPressed = false;
 // X = 88, h = 72, d = 68, b = 66


### PR DESCRIPTION
Updates title with number of alerts.  (Think gmail or twitter tab name.)
I'm open to suggestions on an elegant substitution for the setInterval(...,2000) (polls every 2sec) but this was the least invasive way to add the change, and works well for me locally.
Tested in ff, chrome.