### PR TITLE
Enforce countExtraAchievementGoldens() >=0

### DIFF
--- a/updates.js
+++ b/updates.js
@@ -3743,7 +3743,8 @@ function toggleSetting(setting, elem, fromPortal, updateOnly){
 	}
 
 	function countExtraAchievementGoldens(){
-		return Math.floor((game.global.achievementBonus - 2000) / 500);
+		var extraAchievements =  Math.floor((game.global.achievementBonus - 2000) / 500);
+		return (extraAchievements > 0) ? extraAchievements : 0;
 	}
 
 	var trimpAchievementHelpOn = false;


### PR DESCRIPTION
Before this change, with an achievement percentage < 2000%, this function
returned a negative value and reduced the frequency of golden upgrades.