### PR TITLE
use textContent to assign DOM element content over innerHTML in expensive loops

### DIFF
--- a/updates.js
+++ b/updates.js
@@ -2986,7 +2986,7 @@ function updateLabels() { //Tried just updating as something changes, but seems 
 			toUpdate.owned = parseFloat(toUpdate.owned);
 			if (!(toUpdate.owned > 0)) toUpdate.owned = 0;
 		}
-		document.getElementById(item + "Owned").innerHTML = prettify(Math.floor(toUpdate.owned));
+		document.getElementById(item + "Owned").textContent = prettify(Math.floor(toUpdate.owned));
 		if (toUpdate.max == -1 || document.getElementById(item + "Max") === null) continue;
 		var newMax = toUpdate.max;
 		if (item != "trimps")
@@ -3013,9 +3013,9 @@ function updateLabels() { //Tried just updating as something changes, but seems 
 		elem.innerHTML = (game.options.menu.menuFormatting.enabled) ? prettify(toUpdate.owned) : toUpdate.owned;
 		if (itemA == "Trap") {
 			var trap1 = document.getElementById("trimpTrapText")
-			if (trap1) trap1.innerHTML = prettify(toUpdate.owned);
+			if (trap1) trap1.textContent = prettify(toUpdate.owned);
 			var trap2 = document.getElementById("trimpTrapText2")
-			if (trap2) trap2.innerHTML = prettify(toUpdate.owned);
+			if (trap2) trap2.textContent = prettify(toUpdate.owned);
 		}
 	}
 	//Jobs, check PS here and stuff. Trimps per second is handled by breed() function
@@ -3028,7 +3028,7 @@ function updateLabels() { //Tried just updating as something changes, but seems 
 			continue;
 		}
 		if (document.getElementById(itemB) === null) unlockJob(itemB);
-		document.getElementById(itemB + "Owned").innerHTML = (game.options.menu.menuFormatting.enabled) ? prettify(toUpdate.owned) : toUpdate.owned;
+		document.getElementById(itemB + "Owned").textContent = (game.options.menu.menuFormatting.enabled) ? prettify(toUpdate.owned) : toUpdate.owned;
 		var perSec = (toUpdate.owned * toUpdate.modifier);
 		updatePs(toUpdate, false, itemB);
 	}

--- a/updates.js
+++ b/updates.js
@@ -3048,7 +3048,7 @@ function updateLabels() { //Tried just updating as something changes, but seems 
 		var toUpdate = game.equipment[itemD];
 		if (toUpdate.locked == 1) continue;
 		if (document.getElementById(itemD) === null) drawAllEquipment();
-		document.getElementById(itemD + "Owned").innerHTML = toUpdate.level;
+		document.getElementById(itemD + "Owned").textContent = toUpdate.level;
 	}
 }
 
@@ -3123,14 +3123,14 @@ function updatePs(jobObj, trimps, jobName){ //trimps is true/false, send PS as f
 
 function updateSideTrimps(){
 	var trimps = game.resources.trimps;
-	document.getElementById("trimpsEmployed").innerHTML = prettify(trimps.employed);
+	document.getElementById("trimpsEmployed").textContent = prettify(trimps.employed);
 	var breedCount = (trimps.owned - trimps.employed > 2) ? prettify(Math.floor(trimps.owned - trimps.employed)) : 0;
-	document.getElementById("trimpsUnemployed").innerHTML = breedCount;
-	document.getElementById("maxEmployed").innerHTML = prettify(Math.ceil(trimps.realMax() / 2));
+	document.getElementById("trimpsUnemployed").textContent = breedCount;
+	document.getElementById("maxEmployed").textContent = prettify(Math.ceil(trimps.realMax() / 2));
 	var free = (Math.ceil(trimps.realMax() / 2) - trimps.employed);
 	if (free < 0) free = 0;
 	var s = (free > 1) ? "s" : "";
-	document.getElementById("jobsTitleUnemployed").innerHTML = prettify(free) + " workspace" + s;
+	document.getElementById("jobsTitleUnemployed").textContent = prettify(free) + " workspace" + s;
 }
 
 function unlockBuilding(what) {


### PR DESCRIPTION
I found it odd each game tick takes ~10ms to process while being profiled, of which 30% was the 'game loop' and 70% was in updateLabels.

<img width="495" alt="screen shot 2018-01-10 at 18 23 08" src="https://user-images.githubusercontent.com/197928/34788719-5b1467e8-f633-11e7-8032-e599b67f1fab.png">

By replacing innerHTML assignment with textContent, we stop the browser from having to parse the input as if it were HTML, which will be faster. Have only replaced the use of innerHTML so far in the two functions that showed up on the profile trace.

I'm not too far into the game but this is safe as long as prettify doesn't return content that actually needs to be parsed. From what I can tell, this is only when the value passed to prettify is `Infinity`, 

Will probably keep digging at perf here since Trimps makes my 2014 MBP quite unhappy when the browser window is maximised.