### PR TITLE
Add a feature to import perks from a string

### DIFF
--- a/index.html
+++ b/index.html
@@ -1036,6 +1036,9 @@
 						<li role="presentation" class="tabNotEnabled" id="presetTabRename" onclick="renamePerkPreset(true)" onmouseover="tooltip('Perk Preset', null, event, 'Rename')" onmouseout="tooltip('hide')">
 							<a>Rename</a>
 						</li>
+						<li role="presentation" class="tabNotEnabled" id="presetTabImport" onclick="tooltip('Import Perks', null, 'update')" onmouseover="tooltip('Perk Preset', null, event, 'Import')" onmouseout="tooltip('hide')">
+							<a>Import</a>
+						</li>
 				</ul>
 			</div>
 				<div id="pnumTabs" class="numTabs">

--- a/updates.js
+++ b/updates.js
@@ -318,6 +318,10 @@ function tooltip(what, isItIn, event, textString, attachFunction, numCheck, rena
 			tooltipText = "Click to load your currently selected perk preset.";
 			if (!game.global.respecActive) tooltipText += " <p class='red'>You must have your Respec active to load a preset!</p>";
 		}
+		else if (textString == "Import"){
+			what = "Import Perk Preset";
+			tooltipText = "Click to import a perk setup from a text string";
+		}
 		else if (textString > 0 && textString <= 3){
 			var preset = game.global["perkPreset" + textString];
 			if (typeof preset === 'undefined') return;
@@ -680,6 +684,18 @@ function tooltip(what, isItIn, event, textString, attachFunction, numCheck, rena
 		ondisplay = function () {
 			document.getElementById('importBox').focus();
 		}
+	}
+	if (what == "Import Perks"){
+		tooltipText = "Import your perks from a text string!<br/><br/><textarea spellcheck='false' id='perkImportBox' style='width: 100%' rows='5'></textarea>";
+		costText = "<p class='red'></p>";
+		costText += "<div id='confirmTooltipBtn' class='btn btn-info' onclick='this.previousSibling.innerText = importPerks()'>Import</div>";
+		costText += "<div class='btn btn-info' onclick='cancelTooltip()'>Cancel</div></div>";
+		game.global.lockTooltip = true;
+		elem.style.left = "33.75%";
+		elem.style.top = "25%";
+		ondisplay = function () {
+			document.getElementById('perkImportBox').focus();
+		};
 	}
 	if (what == "AutoPrestige"){
 		tooltipText = '<p>Your scientists have come a long way since you first crashed here, and can now purchase prestige upgrades automatically for you with hardly any catastrophic mistakes. They understand the word "No" and the following three commands: </p><p><b>AutoPrestige All</b> will always purchase the cheapest prestige available first.</p><p><b>Weapons Only</b> as you may be able to guess, will only purchase Weapon prestiges.</p><p><b>Weapons First</b> will only purchase Weapon prestiges unless the cheapest Armor prestige is less than 5% of the cost of the cheapest Weapon.</p>';


### PR DESCRIPTION
This adds an “Import” button to the perk screen, next to “Save”, “Load” and “Rename”. When clicked, this button opens a popup that lets the user enter a perkstring. Upon confirming, the perk levels are set to match those specified in the perk string. A respec will be spent if (and only if) it is needed.

The perk string is meant to be generated by external tools, and so it has to be checked carefully to prevent cheating and mistakes. If any error is encountered, the import function returns early, without modifying any perk levels or helium counts, and reports the error to the user. Here’s a list of the error cases that are checked, and the associated error messages:

* The string is not LZ-encoded JSON: "This doesn't look like a valid perk string."
* The JSON has a `global` key: "This looks like a save string, rather than a perk string. To import a save string, use the Import button on the main screen."
* The JSON has a key that is neither `global` nor a valid perk name: "Perk *perkname* doesn't exist."
* The value associated with a perk name isn’t a valid level for this perk: "Cannot set *perkname* to level *level*.". This includes negative values, NaNs, infinites, values above the cap for capped perks, and any value for locked perks.
* The perk setup tries to lower a perk level, but `game.global.canRespec` is `false`:  "This perk setup would require a respec, but you don't have one available."
* The perk setup requires more Helium than is available: "You don't have enough Helium to afford this perk setup."

Currently, the perkstring is LZ-encoded JSON of the form {perk_name: level}. It could be changed to a simple comma-separated list, such as `Looting=42,Power=51,…`. This would make it easier to edit by hand (which isn’t an issue, since it is double-checked anyway). If you would prefer this format, just tell me and I’ll change it.