### PR TITLE
Add metric notation (closes #51)

### DIFF
--- a/config.js
+++ b/config.js
@@ -445,8 +445,8 @@ var toReturn = {
 			standardNotation: {
 				enabled: 1,
 				extraTags: "layout",
-				description: "Swap between Standard Formatting (12.7M, 540B), Engineering Notation (12.7e6, 540e9), Scientific Notation (1.27e7, 5.40e11), Alphabetic Notation (12.7b, 540c), and Hybrid Notation (Standard up to e96, then Engineering. Mimics Standard pre 4.6).",
-				titles: ["Scientific Notation", "Standard Formatting", "Engineering Notation", "Alphabetic Notation", "Hybrid Notation"],
+				description: "Swap between Standard Formatting (12.7M, 540B), Engineering Notation (12.7e6, 540e9), Scientific Notation (1.27e7, 5.40e11), Alphabetic Notation (12.7b, 540c), Hybrid Notation (Standard up to e96, then Engineering. Mimics Standard pre 4.6) and Metric Notation (12.7M, 540G).",
+				titles: ["Scientific Notation", "Standard Formatting", "Engineering Notation", "Alphabetic Notation", "Hybrid Notation", "Metric Notation"],
 				onToggle: function () {
 					document.getElementById("tab5Text").innerHTML = "+" + prettify(game.global.lastCustomAmt);
 				}

--- a/updates.js
+++ b/updates.js
@@ -2198,11 +2198,16 @@ function prettify(number) {
             'Nog', 'Na', 'Un', 'Dn', 'Tn', 'Qan', 'Qin', 'Sxn', 'Spn', 'On',
             'Nn', 'Ct', 'Uc'
 		];
+		var metric_prefixes = [
+			'k', 'M', 'G', 'T', 'P', 'E', 'Z', 'Y'
+		];
 		var suffix;
-		if (game.options.menu.standardNotation.enabled == 2 || (game.options.menu.standardNotation.enabled == 1 && base > suffices.length) || (game.options.menu.standardNotation.enabled == 4 && base > 31))
-			suffix = "e" + ((base) * 3);
-		else if (game.options.menu.standardNotation.enabled && base <= suffices.length)
+		if ((game.options.menu.standardNotation.enabled == 1 || (game.options.menu.standardNotation == 4 && base <= 31)) && base <= suffices.length)
 			suffix = suffices[base-1];
+		else if (game.options.menu.standardNotation.enabled == 5 && base <= metric_prefixes.length)
+			suffix = metric_prefixes[base-1];
+		else if (game.options.menu.standardNotation.enabled != 0)
+			suffix = "e" + ((base) * 3);
 		else
 		{
 			var exponent = parseFloat(numberTmp).toExponential(2);


### PR DESCRIPTION
Add metric prefixes from kilo up to Yotta.
Switches to engineering notation beyond that.