### PR TITLE
Fix displayed enemy damage when trimp CC >100%

### DIFF
--- a/main.js
+++ b/main.js
@@ -8183,17 +8183,17 @@ function calculateDamage(number, buildString, isTrimp, noCheckAchieve, cell) { /
     var max = Math.ceil(number + (number * maxFluct));
     if (buildString) {
 		if (isTrimp) {
-			if (!noCheckAchieve) checkAchieve("damage", max);
-			else return max;
-		}
-		var critChance = getPlayerCritChance();
-		if (critChance >= 1){
-			var critDamage = getPlayerCritDamageMult();
-			number *= critDamage;
-			if (critChance >= 3) number *= getMegaCritDamageMult(3);
-			else if (critChance >= 2) number *= getMegaCritDamageMult(2);
-			min = Math.floor(number * (1 - minFluct));
-			max = Math.ceil(number + (number * maxFluct));
+			if (noCheckAchieve) return max;
+			var critChance = getPlayerCritChance();
+			if (critChance >= 1){
+				var critDamage = getPlayerCritDamageMult();
+				number *= critDamage;
+				if (critChance >= 3) number *= getMegaCritDamageMult(3);
+				else if (critChance >= 2) number *= getMegaCritDamageMult(2);
+				min = Math.floor(number * (1 - minFluct));
+				max = Math.ceil(number + (number * maxFluct));
+			}
+			checkAchieve("damage", max);
 		}
 		return prettify(min) + "-" + prettify(max);
     }


### PR DESCRIPTION
v4.8 added some logic to display the trimps’ crit damage when
the trimps have over 100% CC. However, that logic was also incorrectly
applying to the bad guys, causing the bad guys’ displayed damage to be
higher than their real damage by a factor equal to the trimps’ CD.
This is easily fixed by nesting the crit logic inside the `isTrimp` check.

In addition, Trimp Damage achievements didn’t account for this new multiplier
to displayed damage. This commit also fixes that.