### PR TITLE
Rework loot averaging so jestimps can be included

### DIFF
--- a/config.js
+++ b/config.js
@@ -429,10 +429,7 @@ var toReturn = {
 			owned: false,
 			fire: function () {
 				game.unlocks.goldMaps = true;
-				for (var item in game.global.mapsOwnedArray){
-					game.global.mapsOwnedArray[item].loot = parseFloat(game.global.mapsOwnedArray[item].loot) + 1;
-					if (!game.global.mapsOwnedArray[item].noRecycle) document.getElementById(game.global.mapsOwnedArray[item].id).className += " goldMap";
-				}
+				refreshMaps();
 			}
 		},
 		quickTrimps: {
@@ -1850,7 +1847,7 @@ var toReturn = {
 						game.buildings.Warpstation.craftTime = 0;
 						addNewSetting('forceQueue');
 					}
-					if (game.global.autoUpgrades) document.getElementById("autoPrestigeBtn").style.display = "block";
+					document.getElementById("autoPrestigeBtn").style.display = "block";
 				}
 			},
 			start: function () {

--- a/config.js
+++ b/config.js
@@ -4211,6 +4211,7 @@ var toReturn = {
 					addHelium(reward);
 					game.challenges.Electricity.stacks = 0;
 					updateElectricityStacks();
+					refreshMaps();
 				}
 			}
 		},
@@ -4315,6 +4316,7 @@ var toReturn = {
 					game.global.challengeActive = "";
 					game.portal.Overkill.locked = false;
 					addNewSetting('overkillColor');
+					refreshMaps();
 				}
 			}
 		},
@@ -5242,7 +5244,6 @@ var toReturn = {
 			title: "The Prison",
 			fire: function () {
 				game.global.mapsUnlocked = true;
-				unlockMapStuff();
 				createMap(80, "The Prison", "Prison", 2.6, 100, 2.6, true);
 				message("You found The Prison! You have a bad feeling about going in...", "Story");
 			}
@@ -7040,7 +7041,7 @@ var toReturn = {
 					}
 				},
 				fire: function () {
-					game.resources.trimps.max += ((game.buildings.Hut.owned) * game.buildings.Hut.increase.by);
+					addMaxHousing(game.buildings.Hut.owned * game.buildings.Hut.increase.by, game.talents.autoStructure.purchased);
 					game.buildings.Hut.increase.by *= 2;
 				}
 			},
@@ -7057,7 +7058,7 @@ var toReturn = {
 					}
 				},
 				fire: function () {
-					game.resources.trimps.max += ((game.buildings.House.owned) * game.buildings.House.increase.by);
+					addMaxHousing(game.buildings.House.owned * game.buildings.House.increase.by, game.talents.autoStructure.purchased);
 					game.buildings.House.increase.by *= 2;
 				}
 			},
@@ -7074,7 +7075,7 @@ var toReturn = {
 					}
 				},
 				fire: function () {
-					game.resources.trimps.max += ((game.buildings.Mansion.owned) * game.buildings.Mansion.increase.by);
+					addMaxHousing(game.buildings.Mansion.owned * game.buildings.Mansion.increase.by, game.talents.autoStructure.purchased);
 					game.buildings.Mansion.increase.by *= 2;
 				}
 			},
@@ -7091,7 +7092,7 @@ var toReturn = {
 					}
 				},
 				fire: function () {
-					game.resources.trimps.max += ((game.buildings.Hotel.owned) * game.buildings.Hotel.increase.by);
+					addMaxHousing(game.buildings.Hotel.owned * game.buildings.Hotel.increase.by, game.talents.autoStructure.purchased);
 					game.buildings.Hotel.increase.by *= 2;
 				}
 			},
@@ -7108,7 +7109,7 @@ var toReturn = {
 					}
 				},
 				fire: function () {
-					game.resources.trimps.max += ((game.buildings.Resort.owned) * game.buildings.Resort.increase.by);
+					addMaxHousing(game.buildings.Resort.owned * game.buildings.Resort.increase.by, game.talents.autoStructure.purchased);
 					game.buildings.Resort.increase.by *= 2;
 				}
 			},

--- a/config.js
+++ b/config.js
@@ -21,7 +21,7 @@
 function newGame () {
 var toReturn = {
 	global: {
-		version: 4.813,
+		version: 4.814,
 		isBeta: false,
 		betaV: 0,
 		killSavesBelow: 0.13,
@@ -241,16 +241,11 @@ var toReturn = {
 			}
 		},
 		lootAvgs: {
-			food: [0],
-			foodTotal: 0,
-			wood: [0],
-			woodTotal: 0,
-			metal: [0],
-			metalTotal: 0,
-			gems: [0],
-			gemsTotal: 0,
-			fragments: [0],
-			fragmentsTotal: 0
+			food: {average:0, accumulator: 0},
+			wood: {average:0, accumulator: 0},
+			metal: {average:0, accumulator: 0},
+			gems: {average:0, accumulator: 0},
+			fragments: {average:0, accumulator: 0},
 		},
 		menu: {
 			buildings: true,
@@ -706,12 +701,14 @@ var toReturn = {
 			useAverages: {
 				extraTags: "popular general",
 				enabled: 0,
-				description: "Toggle whether or not loot from maps and the world should be counted in the loot breakdown and tooltip calculations. Calculates the average of the last two minutes of loot. If you want to clear the last 2 minutes, try toggling it off and on again.",
+				description: "Toggle whether or not loot from maps and the world should be counted in the loot breakdown and tooltip calculations. Calculates a moving average of the loot. If you want to clear the average, try toggling it off and on again.",
 				titles: ["Not Averaging", "Averaging"],
 				onToggle: function () {
 					for (var item in game.global.lootAvgs){
-						if (Array.isArray(game.global.lootAvgs[item])) game.global.lootAvgs[item] = [0];
-						else game.global.lootAvgs[item] = 0;
+						game.global.lootAvgs[item] = {
+							average: 0,
+							accumulator: 0
+						};
 					}
 				}
 			},
@@ -3505,6 +3502,8 @@ var toReturn = {
 		speed: 10,
 		speedTemp: 0,
 		slowdown: false,
+                ewma_alpha: 0.05,
+                ewma_ticks: 10, // 1 second
 	},
 
 	resources: {
@@ -4574,7 +4573,7 @@ var toReturn = {
 				var item = eligible[roll];
 				var amt = simpleSeconds(item, 45);
 				amt = scaleToCurrentMap(amt);
-				addResCheckMax(item, amt);
+				addResCheckMax(item, amt, null, null, true);
 				message("That Jestimp gave you " + prettify(amt) + " " + item + "!", "Loot", "*dice", "exotic", "exotic");
 				game.unlocks.impCount.Jestimp++;
 			}

--- a/index.html
+++ b/index.html
@@ -3,13 +3,13 @@
 <head>
   <meta charset="utf-8">
   
-	<title>Trimps 4.813</title>
+	<title>Trimps 4.814</title>
 	<meta name="description" content="Trimps">
 	<meta name="author" content="Brownprobe">
 	<link rel="stylesheet" href="css/bootstrap.css">
 	<link rel="stylesheet" href="fonts/icomoon/style.css">
 	<link rel="icon" href="favicon.ico" type="image/x-icon">
-	<link rel="stylesheet" type="text/css" href="css/style.css?11" />
+	<link rel="stylesheet" type="text/css" href="css/style.css?12" />
 <script>
   (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
   (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
@@ -1261,9 +1261,9 @@
 	<script type="text/javascript" src="Playfab/PlayFabSDK/PlayFabClientApi.js"></script>
 	<script type="text/javascript" src="lz-string.js"></script>
 	<script type="text/javascript" src="decimal.min.js"></script>
-	<script type="text/javascript" src="config.js?11"></script>
-	<script type="text/javascript" src="updates.js?11"></script>
-	<script type="text/javascript" src="main.js?11"></script>
+	<script type="text/javascript" src="config.js?12"></script>
+	<script type="text/javascript" src="updates.js?12"></script>
+	<script type="text/javascript" src="main.js?12"></script>
 	
 </body>
 

--- a/indexKong.html
+++ b/indexKong.html
@@ -3,12 +3,12 @@
 <head>
   <meta charset="utf-8">
 
-	<title>Trimps 4.813 (Kongregate Version)</title>
+	<title>Trimps 4.814 (Kongregate Version)</title>
 	<meta name="description" content="Trimps">
 	<meta name="author" content="Brownprobe">
     <link rel="stylesheet" href="css/bootstrap.css">
 	<link rel="stylesheet" href="fonts/icomoon/style.css">
-    <link rel="stylesheet" type="text/css" href="css/style.css?11" />
+    <link rel="stylesheet" type="text/css" href="css/style.css?12" />
 <script>
   (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
   (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
@@ -1365,9 +1365,9 @@ var kongregate = parent.kongregateAPI.getAPI();
 	<script type="text/javascript" src="Playfab/PlayFabSDK/PlayFabClientApi.js"></script>
 	<script type="text/javascript" src="lz-string.js"></script>
 	<script type="text/javascript" src="decimal.min.js"></script>
-	<script type="text/javascript" src="config.js?11"></script>
-	<script type="text/javascript" src="updates.js?11"></script>
-	<script type="text/javascript" src="main.js?11"></script>
+	<script type="text/javascript" src="config.js?12"></script>
+	<script type="text/javascript" src="updates.js?12"></script>
+	<script type="text/javascript" src="main.js?12"></script>
 	<script type="text/javascript">
 		document.body.addEventListener('DOMMouseScroll', onWheel, true);
 		document.body.addEventListener('mousewheel', onWheel, true);

--- a/main.js
+++ b/main.js
@@ -7441,7 +7441,8 @@ function battleCoordinator(makeUp) {
 function battle(force) {
 	var trimps = game.resources.trimps;
 	var trimpsMax = trimps.realMax();
-    if (game.global.fighting) return;
+	if (game.global.fighting) return;
+	if (game.global.soldierHealth <= 0) document.getElementById('critSpan').innerHTML = "";
     if ((game.global.switchToMaps || game.global.switchToWorld) && trimps.soldiers === 0) {
         mapsSwitch();
         return;
@@ -10503,7 +10504,6 @@ function fight(makeUp) {
 	var thisKillsTheTrimp = function() {
 		impOverkill -= game.global.soldierHealth;
 		game.global.soldierHealth = 0;
-		critTier = 0;
 	};
 	var thisKillsTheBadGuy = function() {
 		cell.health = 0;

--- a/main.js
+++ b/main.js
@@ -1303,6 +1303,7 @@ function abandonChallenge(restart){
 	}
 	if (challengeName != "Daily")
 		message("Your challenge has been abandoned.", "Notices");
+	refreshMaps();
 }
 
 function checkChallengeSquaredAllowed(){
@@ -3443,7 +3444,7 @@ function breed() {
 	var remainingTime = timeRemaining;
 	timeRemaining += " Secs";
 		//Display full breed time if desired
-	var totalTimeText = totalTime.toFixed(1);
+	var totalTimeText = Math.ceil(totalTime * 10) / 10;
 	if (game.options.menu.showFullBreed.enabled){
 		fullBreed = totalTimeText + " Secs";
 		timeRemaining += " / " + fullBreed;
@@ -4936,8 +4937,8 @@ function getRandomBySteps(steps, mod, fromBones){
 		var possible = ((steps[1] - steps[0]) / steps[2]);
 		var roll = getRandomIntSeeded(seed, 0, possible + 1);
 		var result = steps[0] + (roll * steps[2]);
-		result = Math.floor(result * 100) / 100;
-		return ([result, (possible - roll)]);
+		result = Math.round(result * 100) / 100;
+		return ([result, Math.round(possible - roll)]);
 }
 
 function getHeirloomZoneBreakpoint(zone){
@@ -6488,8 +6489,8 @@ function generatorTick(fromOverclock){
 function addMaxHousing(amt, giveTrimps){
 	var wasFull = (game.resources.trimps.owned == game.resources.trimps.realMax());
 	game.resources.trimps.max += amt;
-	if (game.global.challengeActive == "Trapper") return amt;
 	amt = scaleNumberForBonusHousing(amt);
+	if (game.global.challengeActive == "Trapper") return amt;
 	if (!giveTrimps) return amt;
 	if (wasFull){
 		game.resources.trimps.owned = game.resources.trimps.realMax();
@@ -8751,7 +8752,7 @@ function nextWorld() {
 		//Without Hiring Anything
 		var jobCount = 0;
 		for (var job in game.jobs) jobCount += game.jobs[job].owned; //Dragimp adds 1
-		if (jobCount - game.jobs.Dragimp.owned == 0 && game.stats.trimpsFired.value == 0) giveSingleAchieve("Unemployment");
+		if (jobCount - game.jobs.Dragimp.owned - game.jobs.Amalgamator.owned == 0 && game.stats.trimpsFired.value == 0) giveSingleAchieve("Unemployment");
 	}
 	else if (game.global.world == 65) checkChallengeSquaredAllowed();
 	else if (game.global.world == 75 && checkHousing(true) == 0) giveSingleAchieve("Tent City");
@@ -10829,7 +10830,9 @@ function updateAntiStacks(){
 	if (game.global.antiStacks > 0){
 		var number = ((game.global.antiStacks * game.portal.Anticipation.level * game.portal.Anticipation.modifier));
 		number = Math.floor(number * 100);
-		elem.innerHTML = '<span class="badge antiBadge" onmouseover="tooltip(\'Anticipation\', \'customText\', event, \'Your Trimps are dealing ' + number + '% extra damage for taking ' + game.global.antiStacks + ' seconds to populate.\')" onmouseout="tooltip(\'hide\')">' + game.global.antiStacks + '<span class="icomoon icon-target2"></span></span>';
+		var verb = game.jobs.Amalgamator.owned > 0 ? "prepare" : "populate";
+		var s = game.global.antiStacks == 1 ? '' : 's';
+		elem.innerHTML = '<span class="badge antiBadge" onmouseover="tooltip(\'Anticipation\', \'customText\', event, \'Your Trimps are dealing ' + number + '% extra damage for taking ' + game.global.antiStacks + ' second' + s + ' to ' + verb + '.\')" onmouseout="tooltip(\'hide\')">' + game.global.antiStacks + '<span class="icomoon icon-target2"></span></span>';
 	}
 	else elem.innerHTML = "";
 }

--- a/updates.html
+++ b/updates.html
@@ -52,6 +52,21 @@
 <div id="wrapper">
 <span style="font-size: 1.3em; font-weight: bold; display: block; width: 100%; text-align: center">Trimps Updates!</span>
 <ul class="betterList">
+	<li>4.814 - 7/21/18</li>
+	<ul>
+		<li>UI/QOL</li>
+		<li>Replaced the old method of loot averaging with a new one based on <a href='https://en.wikipedia.org/wiki/Moving_average#Exponential_moving_average'>exponentially weighted moving average</a>. Since this method is less jumpy, Jestimp is once again included in average loot calculations. Huge thanks to ponkan_pinoy and Grimy on Discord for putting this together!</li>
+		<li>AutoPrestige can now run if AutoUpgrade is off</li>
+		<li>Added a "Download as File" button to the export menu, which will allow you to save a .txt file of your game progress directly to your computer.</li>
+		<li>Clarified the reward text for the Scientist III challenge</li>
+	</ul>
+	<ul>
+		<li>Bug Fixes</li>
+		<li>Fixed the link to the Trimps subreddit on the crash popup</li>
+		<li>Purchasing Golden Maps now properly updates the displayed value of loot on maps in the Map Chamber</li>
+	</ul>
+</ul>
+<ul class="betterList">
 	<li>4.813 - 7/14/18</li>
 	<ul>
 		<li>UI/QOL</li>

--- a/updates.html
+++ b/updates.html
@@ -52,18 +52,30 @@
 <div id="wrapper">
 <span style="font-size: 1.3em; font-weight: bold; display: block; width: 100%; text-align: center">Trimps Updates!</span>
 <ul class="betterList">
-	<li>4.814 - 7/21/18</li>
+	<li>4.814 - 7/22/18</li>
 	<ul>
 		<li>UI/QOL</li>
 		<li>Replaced the old method of loot averaging with a new one based on <a href='https://en.wikipedia.org/wiki/Moving_average#Exponential_moving_average'>exponentially weighted moving average</a>. Since this method is less jumpy, Jestimp is once again included in average loot calculations. Huge thanks to ponkan_pinoy and Grimy on Discord for putting this together!</li>
 		<li>AutoPrestige can now run if AutoUpgrade is off</li>
 		<li>Added a "Download as File" button to the export menu, which will allow you to save a .txt file of your game progress directly to your computer.</li>
 		<li>Clarified the reward text for the Scientist III challenge</li>
+		<li>The displayed breed timer now rounds up, to be more consistent with how breeding actually works</li>
+		<li>When running a unique map is necessary to complete the current challenge, it is shown in green rather than red</li>
+		<li>Slightly changed the wording of the Anticipation tooltip when you have an Amalgamator</li>
+		<li>When Trimps get a crit and then die on the same turn, the "Crit!" message now briefly appears</li>
 	</ul>
 	<ul>
 		<li>Bug Fixes</li>
+		<li>Most of these bug fixes were done by Grimy. Thanks Grimy!</li>
 		<li>Fixed the link to the Trimps subreddit on the crash popup</li>
 		<li>Purchasing Golden Maps now properly updates the displayed value of loot on maps in the Map Chamber</li>
+		<li>UberHousing upgrades now properly come prefilled with Trimps if you have the AutoStructure upgrade</li>
+		<li>Fixed an issue with rounding on heirloom mods</li>
+		<li>Finding an Amalgamator no longer fails the Unemployment feat</li>
+		<li>Tauntimp text during the Trapper challenge now properly includes Carpentry</li>
+		<li>The Anticipation tooltip now properly says "1 second" instead of seconds</li>
+		<li>Maps and fragments no longer refade in after completing the Prison</li>
+
 	</ul>
 </ul>
 <ul class="betterList">

--- a/updates.js
+++ b/updates.js
@@ -701,16 +701,26 @@ function tooltip(what, isItIn, event, textString, attachFunction, numCheck, rena
 		elem.style.top = "25%";
 	}
 	if (what == "Export"){
+		var saveText = save(true);
 		if (textString){
-			tooltipText = textString + "<br/><br/><textarea id='exportArea' spellcheck='false' style='width: 100%' rows='5'>" + save(true) + "</textarea>";
+			tooltipText = textString + "<br/><br/><textarea id='exportArea' spellcheck='false' style='width: 100%' rows='5'>" + saveText + "</textarea>";
 			what = "Thanks!";
 		}
 		else
-		tooltipText = "This is your save string. There are many like it but this one is yours. Save this save somewhere safe so you can save time next time. <br/><br/><textarea spellcheck='false' id='exportArea' style='width: 100%' rows='5'>" + save(true) + "</textarea>";
+		tooltipText = "This is your save string. There are many like it but this one is yours. Save this save somewhere safe so you can save time next time. <br/><br/><textarea spellcheck='false' id='exportArea' style='width: 100%' rows='5'>" + saveText + "</textarea>";
 		costText = "<div class='maxCenter'><div id='confirmTooltipBtn' class='btn btn-info' onclick='cancelTooltip()'>Got it</div>";
 		if (document.queryCommandSupported('copy')){
 			costText += "<div id='clipBoardBtn' class='btn btn-success'>Copy to Clipboard</div>";
 		}
+		costText += "<a id='downloadLink' target='_blank' download='Trimps Save P" + game.global.totalPortals + " Z" + game.global.world + "', href=";
+		if (Blob !== null) {
+			var blob = new Blob([saveText], {type: 'text/plain'});
+			var uri = URL.createObjectURL(blob);
+			costText += uri;
+		} else {
+			costText += 'data:text/plain,' + encodeURIComponent(saveText);
+		}
+		costText += " ><div class='btn btn-danger' id='downloadBtn'>Download as File</div></a>";
 		costText += "</div>";
 		ondisplay = tooltips.handleCopyButton();
 		game.global.lockTooltip = true;
@@ -1338,7 +1348,7 @@ function getPsString(what, rawNum) {
 	//Add Loot	ALWAYS LAST
 	if (game.options.menu.useAverages.enabled){
 		var avg = getAvgLootSecond(what);
-		if (avg > 0) {
+		if (avg > 0.001) {
 			currentCalc += avg;
 			textString += "<tr><td class='bdTitle'>Average Loot</td><td class='bdPercent'>+ " + prettify(avg) + "</td><td class='bdNumber'>" + prettify(currentCalc) + "</td></tr>";
 		}
@@ -2716,7 +2726,10 @@ function resetGame(keepPortal) {
 		if (sLevel >= 1) applyS1();
 		if (sLevel >= 2) applyS2();
 		if (sLevel >= 3) applyS3();
-		if (sLevel >= 4) game.buildings.Warpstation.craftTime = 0;
+		if (sLevel >= 4) {
+			game.buildings.Warpstation.craftTime = 0;
+			document.getElementById("autoPrestigeBtn").style.display = "block";
+		}
 		if (sLevel >= 5) applyS5();
 		if (game.global.autoUpgradesAvailable) document.getElementById("autoUpgradeBtn").style.display = "block";
 		if (game.global.autoStorageAvailable) {
@@ -4417,7 +4430,7 @@ var tooltips = {};
  */
 tooltips.showError = function (textString) {
 	var tooltip = "<p>Well this is embarrassing. Trimps has encountered an error. Try refreshing the page.</p>";
-	tooltip += "<p>It would be awesome if you post the following to the <a href='reddit.com/r/Trimps/'>trimps subreddit</a> or email it to trimpsgame@gmail.com</p>";
+	tooltip += "<p>It would be awesome if you post the following to the <a href='https://reddit.com/r/Trimps/'>trimps subreddit</a> or email it to trimpsgame@gmail.com</p>";
 	tooltip += "Note: Saving has been disabled.<br/><br/><textarea id='exportArea' spellcheck='false' style='width: 100%' rows='5'>";
 	var bugReport = "--BEGIN ERROR STACK--\n";
 	bugReport += textString + '\n';

--- a/updates.js
+++ b/updates.js
@@ -3503,6 +3503,15 @@ function refreshMaps(){
 }
 
 function getUniqueColor(item){
+	if (!game.global.runningChallengeSquared) {
+		if (item.name == "The Prison" && game.global.challengeActive == "Electricity")
+			return " noRecycle";
+		if (item.name == "The Prison" && game.global.challengeActive == "Mapocalypse")
+			return " noRecycle";
+		if (item.name == "Imploding Star" && game.global.challengeActive == "Devastation")
+			return " noRecycle";
+	}
+
 	if (item.location && game.mapConfig.locations[item.location].upgrade){
 			var upgrade = game.mapConfig.locations[item.location].upgrade;
 			upgrade = (typeof upgrade === 'object') ? upgrade[0] : upgrade;
@@ -4208,7 +4217,7 @@ function toggleSetting(setting, elem, fromPortal, updateOnly, backwards){
 				for (var job in game.jobs) {
 					jobCount += game.jobs[job].owned;
 				}
-				return (game.global.world < 60 && jobCount - game.jobs.Dragimp.owned == 0 && game.stats.trimpsFired.value == 0);
+				return (game.global.world < 60 && jobCount - game.jobs.Dragimp.owned - game.jobs.Amalgamator.owned == 0 && game.stats.trimpsFired.value == 0);
 			},
 			Trimp_is_Poison: function () {
 				return (game.global.challengeActive == "Toxicity" && game.challenges.Toxicity.highestStacks <= 400);

--- a/updates.js
+++ b/updates.js
@@ -712,7 +712,7 @@ function tooltip(what, isItIn, event, textString, attachFunction, numCheck, rena
 		if (document.queryCommandSupported('copy')){
 			costText += "<div id='clipBoardBtn' class='btn btn-success'>Copy to Clipboard</div>";
 		}
-		costText += "<a id='downloadLink' target='_blank' download='Trimps Save P" + game.global.totalPortals + " Z" + game.global.world + "', href=";
+		costText += "<a id='downloadLink' target='_blank' download='Trimps Save P" + game.global.totalPortals + " Z" + game.global.world + ".txt', href=";
 		if (Blob !== null) {
 			var blob = new Blob([saveText], {type: 'text/plain'});
 			var uri = URL.createObjectURL(blob);


### PR DESCRIPTION
Jestimps were removed from loot averaging because they made the average too jumpy. This is a known weakness of the method used (a simple moving average). This change implements an [exponentially-weighted moving average](https://en.wikipedia.org/wiki/Moving_average#Exponential_moving_average) (that's the `ewma` prefix in the code), which is more resilient to jumpiness due to huge irregular spikes (like what happens when you get a jestimp). 

The parameter `game.settings.ewma_alpha` controls the smoothness of the average -- it should lie between 0 and 1 (exclusive) and lower values make the average smoother, at the cost of making the average lag more. It's currently set to 0.05, which has the following properties:

* If there's no loot over one averaging period (1 second), the average will drop 5%
* Getting 20x the average loot over one averaging period will double the average (thanks Grimy!)

The averaging period is also given a name (`game.settings.ewma_ticks`) instead of being a magic number so that it can be tweaked if necessary from one place, instead of having to remember to change both `gameLoop()` and `curateAvgs()`. The averaging period was changed from 3 seconds to 1 second to make the average smoother.