### PR TITLE
Support for lower level map presets & extended confirmhole options

### DIFF
--- a/config.js
+++ b/config.js
@@ -219,7 +219,8 @@ var toReturn = {
 				biome: "Random",
 				specMod: "0",
 				perf: false,
-				extra: 0
+				extra: 0,
+				lowerLevel: 0
 			},
 			p2: {
 				loot: 0,
@@ -228,7 +229,8 @@ var toReturn = {
 				biome: "Random",
 				specMod: "0",
 				perf: false,
-				extra: 0				
+				extra: 0,
+				lowerLevel: 0
 			},
 			p3: {
 				loot: 0,
@@ -237,7 +239,8 @@ var toReturn = {
 				biome: "Random",
 				specMod: "0",
 				perf: false,
-				extra: 0
+				extra: 0,
+				lowerLevel: 0
 			}
 		},
 		lootAvgs: {

--- a/config.js
+++ b/config.js
@@ -589,7 +589,7 @@ var toReturn = {
 				enabled: 1,
 				extraTags: "alerts",
 				description: "Toggles on or off the confirmation popup on scary purchases like Wormholes.",
-				titles: ["Not Confirming", "Confirming"],
+				titles: ["No Confirmation", "Confirm All", "Only Wormholes"],
 			},
 			lockOnUnlock: {
 				enabled: 0,

--- a/main.js
+++ b/main.js
@@ -3283,7 +3283,7 @@ function buyUpgrade(what, confirmed, noTip, heldCtrl) {
 	var canAfford = canAffordTwoLevel(upgrade);
 	if (!canAfford) return false;
 	var usingCtrl = (typeof heldCtrl !== 'undefined') ? heldCtrl : (game.options.menu.ctrlGigas.enabled == 1 && what == "Gigastation") ? true : ctrlPressed;
-	if (what == "Gigastation" && !confirmed && game.options.menu.confirmhole.enabled == 1){ // Zxv: added support for extra confirmhole settings
+	if (what == "Gigastation" && !confirmed && game.options.menu.confirmhole.enabled == 1){
 		tooltip('Confirm Purchase', null, 'update', 'You are about to purchase a Gigastation, <b>which is not a renewable upgrade</b>. Make sure you have purchased all of the Warpstations you can afford first!', 'buyUpgrade(\'Gigastation\', true, false, ' + usingCtrl + ')');
 		return;
 	}

--- a/main.js
+++ b/main.js
@@ -2858,10 +2858,10 @@ function buyBuilding(what, confirmed, fromAuto, forceAmt) {
 	var purchaseAmt = 1;
 	if (forceAmt) purchaseAmt = Math.min(forceAmt, calculateMaxAfford(toBuy, true, false, false, true));
 	else if (!toBuy.percent) purchaseAmt = (game.global.buyAmt == "Max") ? calculateMaxAfford(toBuy, true, false) : game.global.buyAmt;
-    if (typeof toBuy === 'undefined') return false;
-    var canAfford = ((forceAmt) ? canAffordBuilding(what, false, false, false, false, purchaseAmt) : canAffordBuilding(what));
+	if (typeof toBuy === 'undefined') return false;
+	var canAfford = ((forceAmt) ? canAffordBuilding(what, false, false, false, false, purchaseAmt) : canAffordBuilding(what));
 	if (canAfford){
-		if (what == "Wormhole" && !confirmed && game.options.menu.confirmhole.enabled && !fromAuto){
+		if (what == "Wormhole" && !confirmed && (game.options.menu.confirmhole.enabled == 1 || game.options.menu.confirmhole.enabled == 2) && !fromAuto){
 			tooltip('Confirm Purchase', null, 'update', 'You are about to purchase ' + purchaseAmt + ' Wormholes, <b>which cost helium</b>. Make sure you can earn back what you spend!', 'buyBuilding(\'Wormhole\', true, false, ' + purchaseAmt + ')');
 			return false;
 		}
@@ -3275,43 +3275,43 @@ function canAffordCoordinationTrimps(){
 function buyUpgrade(what, confirmed, noTip, heldCtrl) {
 	if (game.options.menu.pauseGame.enabled) return;
 	if (!confirmed && !noTip && game.options.menu.lockOnUnlock.enabled == 1 && (new Date().getTime() - 1000 <= game.global.lastUnlock)) return;
-    if (what == "Coordination") {
-       if (!canAffordCoordinationTrimps()) return false;
-    }
-    var upgrade = game.upgrades[what];
+	if (what == "Coordination") {
+	   if (!canAffordCoordinationTrimps()) return false;
+	}
+	var upgrade = game.upgrades[what];
 	if (upgrade.locked == 1) return;
-    var canAfford = canAffordTwoLevel(upgrade);
-    if (!canAfford) return false;
-	var usingCtrl = (typeof heldCtrl !== 'undefined') ? heldCtrl : (game.options.menu.ctrlGigas.enabled && what == "Gigastation") ? true : ctrlPressed;
-	if (what == "Gigastation" && !confirmed && game.options.menu.confirmhole.enabled){
+	var canAfford = canAffordTwoLevel(upgrade);
+	if (!canAfford) return false;
+	var usingCtrl = (typeof heldCtrl !== 'undefined') ? heldCtrl : (game.options.menu.ctrlGigas.enabled == 1 && what == "Gigastation") ? true : ctrlPressed;
+	if (what == "Gigastation" && !confirmed && game.options.menu.confirmhole.enabled == 1){ // Zxv: added support for extra confirmhole settings
 		tooltip('Confirm Purchase', null, 'update', 'You are about to purchase a Gigastation, <b>which is not a renewable upgrade</b>. Make sure you have purchased all of the Warpstations you can afford first!', 'buyUpgrade(\'Gigastation\', true, false, ' + usingCtrl + ')');
 		return;
 	}
-	if (what == "Shieldblock" && !confirmed && game.options.menu.confirmhole.enabled && game.global.highestLevelCleared >= 30){
+	if (what == "Shieldblock" && !confirmed && game.options.menu.confirmhole.enabled == 1 && game.global.highestLevelCleared >= 30){
 		tooltip('Confirm Purchase', null, 'update', 'You are about to modify your Shield, causing it to block instead of grant health until your next portal. Are you sure?', 'buyUpgrade(\'Shieldblock\', true)');
 		return;
 	}
 	canAfford = canAffordTwoLevel(upgrade, true);
-    upgrade.fire(usingCtrl);
+	upgrade.fire(usingCtrl);
 	upgrade.done++;
 	if (upgrade.prestiges){
 		var resName = (what == "Supershield") ? "wood" : "metal";
 		upgrade.cost.resources[resName] = getNextPrestigeCost(what);
 	}
 	if ((upgrade.allowed - upgrade.done) <= 0) upgrade.locked = 1;
-    var dif = upgrade.allowed - upgrade.done;
-    if (dif > 1) {
+	var dif = upgrade.allowed - upgrade.done;
+	if (dif > 1) {
 		dif -= 1;
-        document.getElementById(what + "Owned").innerHTML = upgrade.done + "(+" + dif + ")";
+		document.getElementById(what + "Owned").innerHTML = upgrade.done + "(+" + dif + ")";
 		if (!noTip) tooltip(what, "upgrades", "update");
-        return true;
-    } else if (dif == 1) {
+		return true;
+	} else if (dif == 1) {
 		if (!noTip) tooltip(what, "upgrades", "update");
-        document.getElementById(what + "Owned").innerHTML = upgrade.done;
-        return true;
-    }
-    document.getElementById("upgradesHere").removeChild(document.getElementById(what));
-    if (!noTip) tooltip("hide");
+		document.getElementById(what + "Owned").innerHTML = upgrade.done;
+		return true;
+	}
+	document.getElementById("upgradesHere").removeChild(document.getElementById(what));
+	if (!noTip) tooltip("hide");
 	return true;
 }
 

--- a/main.js
+++ b/main.js
@@ -3696,6 +3696,7 @@ function saveAdvMaps(){
 	preset.specMod = getSpecialModifierSetting();
 	preset.perf = checkPerfectChecked();
 	preset.extra = getExtraMapLevels();
+	preset.lowerLevel = game.global.world - document.getElementById("mapLevelInput").value;
 }
 
 function getMapPreset(){
@@ -3719,7 +3720,7 @@ function resetAdvMaps(fromClick) {
 	//if !fromClick, loads saved map settings. Otherwise resets to 0
 	var preset = getMapPreset();
 	//level
-	document.getElementById("mapLevelInput").value = (game.options.menu.siphonologyMapLevel.enabled) ? game.global.world - game.portal.Siphonology.level : game.global.world;
+	document.getElementById("mapLevelInput").value = Math.max((game.options.menu.siphonologyMapLevel.enabled) ? game.global.world - game.portal.Siphonology.level: game.global.world - preset.lowerLevel, 6);
 	//sliders
 	var inputs = ["loot", "difficulty", "size"];
 	for (var x = 0; x < inputs.length; x++){


### PR DESCRIPTION
I extended the map presets to remember if the user has selected lower leveled maps.

Additionally, I added an extra value the confirmhole setting. Now, the user can select an option where only wormholes have a confirmation message, while gigastations & shieldblock have no warning.

Known issues: The 2nd and 3rd map presets behave strangely on first load (2nd map preset is -5 levels and 3rd map preset is level NaN). These behave normally once the user saves new values. I didn't want to implement logic to handle this, as I am not super familiar with the save code logic, and I figured BP would be able to bundle this with the new patch.