### PR TITLE
Fix Ctrl stuck on tab change

### DIFF
--- a/main.js
+++ b/main.js
@@ -13804,7 +13804,7 @@ function gameTimeout() {
         runGameLoop(true, now);
         dif -= tick;
         game.global.time += tick;
-		ctrlPressed = false;
+        ctrlReleased();
     }
     runGameLoop(null, now);
     updateLabels();
@@ -13996,21 +13996,32 @@ document.addEventListener('keydown', function (e) {
 			break;
 	}
 }, true);
+function shiftReleased() {
+	if (game.options.menu.tooltips.enabled == false) tooltip('hide');
+	shiftPressed = false;
+}
+function ctrlReleased() {
+	if (!ctrlPressed) return;
+	ctrlPressed = false;
+	checkButtons("upgrades");
+	toggleGeneticistassist(true);
+	if (game.global.buyTab == "nature")
+		updateNatureInfoSpans();
+	if (game.global.buyTab == "talents")
+		displayTalents();
+}
 document.addEventListener('keyup', function(e) {
 	if (e.keyCode == 16){
-		if (game.options.menu.tooltips.enabled == false) tooltip('hide');
-		shiftPressed = false;
+		shiftReleased();
 	}
 	if (e.keyCode == 17 || e.keyCode == 224 || e.keyCode == 91 || e.keyCode == 93){
-		ctrlPressed = false;
-		checkButtons("upgrades");
-		toggleGeneticistassist(true);
-		if (game.global.buyTab == "nature")
-			updateNatureInfoSpans();
-		if (game.global.buyTab == "talents") 
-			displayTalents();
+		ctrlReleased();
 	}
 
+}, true);
+document.addEventListener('blur', function(e) {
+	shiftReleased();
+	ctrlReleased();
 }, true);
 
 


### PR DESCRIPTION
Assume Ctrl and Shift are released when the document gets a 'blur' event.
This fixes the Geneticistassist button getting stuck in configure mode when you press Ctrl+T or other browser shortcuts to toggle tabs.
Also fix the UI not reflecting ctrlReleased=false when returning after a timeout.
Fixes #167