### PR TITLE
Add trap animations to the player spire

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -4963,3 +4963,53 @@ sup{
 	-1px 1px 0 black,
 		1px 1px 0 black;
 }
+
+@keyframes Fire {
+    0% {box-shadow: inset 0px 0px 0px rgba(255, 0, 0, 0.8)}
+    50% {box-shadow: inset 0px 0px 10px rgba(255, 0, 0, 0.8)}
+    100% {box-shadow: inset 0px 0px 0px rgba(255, 0, 0, 0.8)}
+}
+
+@keyframes Frost {
+    0% {box-shadow: inset 0px 0px 0px rgba(100, 175, 255, 0.8)}
+    50% {box-shadow: inset 0px -3px 3px rgba(100, 175, 255, 0.8)}
+    100% {box-shadow: inset 0px 0px 0px rgba(100, 175, 255, 0.8)}
+}
+
+@keyframes Poison {
+    0% {box-shadow: inset 0px 0px 0px rgba(0, 255, 0, 0.8)}
+    33% {box-shadow: inset 2px 0px 4px rgba(0, 255, 0, 0.8)}
+    66% {box-shadow: inset -2px 0px 4px rgba(0, 255, 0, 0.8)}
+    100% {box-shadow: inset 0px 0px 0px rgba(0, 255, 0, 0.8)}
+}
+
+@keyframes Lightning {
+    0% {box-shadow: inset 0px 0px 0px rgba(253, 218, 104, 0.8)}
+    30% {box-shadow: inset 0px 0px 5px rgba(253, 218, 104, 0.8)}
+    40% {box-shadow: inset 0px 0px 5px rgba(253, 218, 104, 0.8)}
+    50% {box-shadow: inset 0px 0px 25px rgba(253, 218, 104, 1)}
+    60% {box-shadow: inset 0px 0px 5px rgba(253, 218, 104, 0.8)}
+    70% {box-shadow: inset 0px 0px 5px rgba(253, 218, 104, 0.8)}
+    100% {box-shadow: inset 0px 0px 0px rgba(253, 218, 104, 0.8)}
+}
+
+@keyframes Strength {
+    0% {box-shadow: inset 0px 0px 0px rgba(0, 0, 0, 0.8)}
+    50% {box-shadow: inset 0px 0px 10px rgba(0, 0, 0, 0.8)}
+    100% {box-shadow: inset 0px 0px 0px rgba(0, 0, 0, 0.8)}
+}
+
+@keyframes Condenser {
+    0% {box-shadow: inset 0px 0px 0px rgba(0, 0, 0, 0.6), inset 0px 0px 0px rgba(0, 0, 0, 0.6)}
+    50% {box-shadow: inset 0px 6px 6px rgba(0, 0, 0, 0.7), inset 0px -6px 10px rgba(0, 0, 0, 0.7)}
+    100% {box-shadow: inset 0px 0px 0px rgba(0, 0, 0, 0.6), inset 0px 0px 0px rgba(0, 0, 0, 0.6)}
+}
+
+@keyframes Knowledge {
+    0% {box-shadow: inset 0px 0px 0px rgba(255, 255, 255, 0.3), inset 0px 0px 0px rgba(255, 255, 255, 0.3), inset 0px 0px 0px rgba(255, 255, 255, 0.3), inset 0px 0px 0px rgba(255, 255, 255, 0.3)}
+    20% {box-shadow: inset 0px 3px 3px rgba(255, 255, 255, 0.3), inset 0px 0px 0px rgba(255, 255, 255, 0.3), inset 0px 0px 0px rgba(255, 255, 255, 0.3), inset 0px 0px 0px rgba(255, 255, 255, 0.3)}
+    40% {box-shadow: inset 0px 3px 3px rgba(255, 255, 255, 0.3), inset 3px 0px 3px rgba(255, 255, 255, 0.3), inset 0px 0px 0px rgba(255, 255, 255, 0.3), inset 0px 0px 0px rgba(255, 255, 255, 0.3)}
+    60% {box-shadow: inset 0px 3px 3px rgba(255, 255, 255, 0.3), inset 3px 0px 3px rgba(255, 255, 255, 0.3), inset 0px -3px 3px rgba(255, 255, 255, 0.3), inset 0px 0px 0px rgba(255, 255, 255, 0.3)}
+    80% {box-shadow: inset 0px 3px 3px rgba(255, 255, 255, 0.3), inset 3px 0px 3px rgba(255, 255, 255, 0.3), inset 0px -3px 3px rgba(255, 255, 255, 0.3), inset -3px 0px 3px rgba(255, 255, 255, 0.3)}
+    100% {box-shadow: inset 0px 0px 0px rgba(255, 255, 255, 0.3), inset 0px 0px 0px rgba(255, 255, 255, 0.3), inset 0px 0px 0px rgba(255, 255, 255, 0.3), inset 0px 0px 0px rgba(255, 255, 255, 0.3)}
+}

--- a/playerSpire.js
+++ b/playerSpire.js
@@ -41,7 +41,8 @@ var playerSpire = {
         enemyIcons: true,
         trapIcons: true,
         shockEffect: true,
-        percentHealth: false
+        percentHealth: false,
+        trapAnimations: false
     },
     lootAvg: {
         accumulator: 0,
@@ -91,6 +92,7 @@ var playerSpire = {
             enemyIcons: true,
             trapIcons: true,
             percentHealth: false,
+            trapAnimations: false
         }
         this.lootAvg = {
             accumulator: 0,
@@ -265,6 +267,7 @@ var playerSpire = {
         if (!playerSpireTraps.Lightning.locked)
         text += "<span class='spireOption'>Shock Effect: " + buildNiceCheckbox('spireshockEffect', '', this.settings.shockEffect) + "</span>";
         text += "<span class='spireOption'>Health as %: " + buildNiceCheckbox('spirepercentHealth', '', this.settings.percentHealth) + "</span>";
+        text += "<span class='spireOption'>Trap Animations: " + buildNiceCheckbox('spiretrapAnimations', '', this.settings.trapAnimations) + "</span>";
         text += "</div>";
         tooltip("Spire Settings", 'customText', 'lock', text, "<span class='btn btn-info' onclick='playerSpire.saveSettings()'>Save</span><span class='btn btn-danger' onclick='cancelTooltip()'>Cancel</span>", "hi", "hi");
     },
@@ -907,7 +910,12 @@ var playerSpire = {
         if (!this.popupOpen) return;
         var elem = document.getElementById('playerSpireCell' + cellNumber + 'enemy');
         if (!elem) return;
-        elem.innerHTML = this.getEnemyHtml(cellNumber);
+        var drawnCell = document.getElementById('playerSpireCell' + cellNumber);
+        var enemyHTML = this.getEnemyHtml(cellNumber);
+        elem.innerHTML = enemyHTML;
+        if (!this.settings.trapAnimations) return;
+        if (enemyHTML === "") drawnCell.style.animation = "";
+        else drawnCell.style.animation = playerSpire.layout[cellNumber].trap.name + " 1s infinite";
     },
     getThreatChange: function(isKill, enemy, location){
         var base = 2;


### PR DESCRIPTION
This is a small commit which adds unique trap animations to each of the trap/tower types in the player spire.

The animations are off by default, and there is a checkbox to enable/disable them located with all the other spire settings.

