### PR TITLE
Increase buying speed for Warpstations w/ Sci IV

### DIFF
--- a/main.js
+++ b/main.js
@@ -15105,6 +15105,7 @@ function buyAutoStructures(){
 		if (!setting[item]) continue;
 		if (typeof setting.NurseryZones !== 'undefined' && game.global.world < setting.NurseryZones && item == "Nursery")
 			continue;
+                if (item == "Warpstation" && game.global.sLevel >= 4 ) maxBuild = 1000;
 		var building = game.buildings[item];
 		var purchased = building.purchased;
 		var buyMax = setting[item].buyMax;


### PR DESCRIPTION
In the case that Scientist IV has been completed and a player has Warpstations being purchased by AutoStructure, it will currently trickle the structure purchases at just 2/10 per execution. This change lets AutoStructure purchase up to 1000 Warpstations in a single go since they’ll skip the building queue.