### PR TITLE
Fix reset map settings saving the new zone offset

### DIFF
--- a/main.js
+++ b/main.js
@@ -5135,7 +5135,6 @@ function resetAdvMaps(fromClick) {
 	//level
 	var levelValue = game.global.world;
 	if (!fromClick && preset.offset != 'd') levelValue += preset.offset;
-	if (fromClick) preset.offset = 'd';
 	document.getElementById("mapLevelInput").value = levelValue;
 	//sliders
 	var inputs = ["loot", "difficulty", "size"];


### PR DESCRIPTION
Before this fix, clicking the reset would actually save the reset zone offset in the currently selected map preset.

You can reproduce the issue right now:
1. Save a map preset with a zone offset (so if in zone 232, pick zone 231 and save).
2. You can now switch between presets and see that the zone offset is kept. Go back to the preset you just saved.
3. Press reset map settings.
4. Switch to another preset and come back, you will have the same dificulty/loot/size/biome as before the reset, but the zone will be your current zone instead of the one you selected before.