### PR TITLE
feat: smart Heirloom pop alert

### DIFF
--- a/config.js
+++ b/config.js
@@ -1002,8 +1002,8 @@ var toReturn = {
 			voidPopups: {
 				extraTags: "alerts",
 				enabled: 1,
-				description: "Decide whether or not you want popups on looting an Heirloom.",
-				titles: ["No Heirloom Pop", "Popping Heirlooms"]
+				description: "Decide whether or not you want popups on looting an Heirloom, depending on the rarity of your currently equipped heirloom",
+				titles: ["No Heirloom Pop", "Popping Heirlooms", "Same or better Heirlooms", "Better Heirlooms"]
 			},
 			detailedPerks: {
 				extraTags: "qol",

--- a/main.js
+++ b/main.js
@@ -6612,6 +6612,30 @@ var lastDisplayedHeirloom = new Date().getTime();
 function displaySelectedHeirloom(modSelected, selectedIndex, fromTooltip, locationOvr, indexOvr, fromPopup, fromSelect){
 	if (fromPopup && !game.options.menu.voidPopups.enabled) return;
 	var heirloom = getSelectedHeirloom(locationOvr, indexOvr);
+
+	if (fromPopup && game.options.menu.voidPopups.enabled > 1) {
+		var currentHeirloom;
+		switch (heirloom.type) {
+			case "Staff":
+				currentHeirloom = game.global.StaffEquipped;
+				break;
+			case "Shield":
+				currentHeirloom = game.global.ShieldEquipped;
+				break;
+			case "Core":
+				currentHeirloom = game.global.CoreEquipped;
+				break;
+		}
+		if (currentHeirloom) {
+			var targetRarity = currentHeirloom.rarity;
+			if (game.options.menu.voidPopups.enabled === 3) {
+				targetRarity++;
+			}
+
+			if (heirloom.rarity < targetRarity) return;
+		}
+	}
+
 	var icon = getHeirloomIcon(heirloom);
 	var animated = (game.options.menu.showHeirloomAnimations.enabled) ? "animated " : "";
 	var html = '<div class="selectedHeirloomItem ' + animated + 'heirloomRare' + heirloom.rarity + '"><div class="row selectedHeirloomRow"><div onclick="tooltip(\'Change Heirloom Icon\', null, \'update\')" class="col-xs-2 selectedHeirloomIcon" id="' + ((fromTooltip) ? 'tooltipHeirloomIcon' : 'selectedHeirloomIcon') + '"><span class="' + icon + '"></span></div><div class="col-xs-10"><h5 aria-label="Rename Heirloom" onclick="renameHeirloom(';


### PR DESCRIPTION
Adds two options to the Heirloom popping alerts:
* `Same or better Heirlooms`, that only alerts the player if the popped Heirloom is the same or better rarity of the currently Heirloom of the same type
* `Better Heirlooms`, which does the same but for strictly rarer Heirlooms