### PR TITLE
small fixes

### DIFF
--- a/config.js
+++ b/config.js
@@ -2751,7 +2751,8 @@ var toReturn = {
 			radSpent: 0,
 			timeLastZone: -1,
 			getMult: function(){
-				return Math.pow(this.getBonusAmt(), getPerkLevel("Tenacity") + getPerkLevel("Masterfulness"));
+				const bonusAmount = this.getBonusAmt();
+				return Math.pow(Math.max(1.1, bonusAmount), getPerkLevel("Tenacity") + getPerkLevel("Masterfulness")); 
 			},
 			getCarryoverMult: function(){
 				var mult = 0.5
@@ -2762,7 +2763,7 @@ var toReturn = {
 				if (game.global.spireActive && !game.global.mapsActive) return 60;
 				var minutes = getZoneMinutes();
 				var lastZone = this.timeLastZone;
-				if (lastZone == -1) lastZone = 0;
+				if (lastZone <= 0) lastZone = this.timeLastZone = 0;
 				if (lastZone > 120) lastZone = 120;
 				minutes += (lastZone * this.getCarryoverMult());
 				if (minutes > 120) minutes = 120;

--- a/main.js
+++ b/main.js
@@ -4227,7 +4227,7 @@ function rewardResource(what, baseAmt, level, checkMapLootScale, givePercentage)
 		if (game.global.challengeActive == "Alchemy") amt *= alchObj.getPotionEffect("Potion of Finding");
 		amt *= alchObj.getPotionEffect("Elixir of Finding");
 	}
-	if (getPerkLevel("Greed")) amt *= game.portal.Greed.getMult();
+	if (getPerkLevel("Greed") || getPerkLevel("Masterfulness")) amt *= game.portal.Greed.getMult();
 	if (game.global.challengeActive == "Quagmire") amt *= game.challenges.Quagmire.getLootMult();
 	if (Fluffy.isRewardActive("wealthy") && what != "helium") amt *= 2;
 	var spireRowBonus = (game.talents.stillRowing.purchased) ? 0.03 : 0.02;
@@ -13676,6 +13676,7 @@ function startSpire(confirmed){
 			if (spireSetting == 1 || (spireSetting == 2 && spireNum >= highestSpire - 1) || (spireSetting == 3 && spireNum >= highestSpire)){
 				game.global.fighting = false;
 				mapsSwitch();
+				if (challengeActive('Berserk')) game.challenges.Berserk.trimpDied();
 			}
 			else handleExitSpireBtn();
 		}
@@ -17209,7 +17210,7 @@ function scaleLootBonuses(amt, ignoreScry){
 	if (game.global.universe == 2 && u2Mutations.tree.Loot.purchased) amt *= 1.5;
 	if (game.global.challengeActive == "Alchemy") amt *= alchObj.getPotionEffect("Potion of Finding");
 	amt *= alchObj.getPotionEffect("Elixir of Finding");
-	if (getPerkLevel("Greed")) amt *= game.portal.Greed.getMult();
+	if (getPerkLevel("Greed") || getPerkLevel("Masterfulness")) amt *= game.portal.Greed.getMult();
 	if (Fluffy.isRewardActive("wealthy")) amt *= 2;
 	if (getUberEmpowerment() == "Wind") amt *= 10;
 	if (!ignoreScry && isScryerBonusActive()) amt *= 2;

--- a/objects.js
+++ b/objects.js
@@ -5178,6 +5178,7 @@ var u2Mutations = {
             reward *= (1 + (getDailyHeliumValue(countDailyWeight()) / 100));
         }
         if (Fluffy.isRewardActive("bigSeeds")) reward *= 10;
+        reward *= u2SpireBonuses.seedDrop();
         reward = calcHeirloomBonus("Staff", "SeedDrop", reward);
         game.global.mutatedSeeds += reward;
         if (typeof game.global.messages.Loot.seeds === 'undefined') game.global.messages.Loot.seeds = true;

--- a/objects.js
+++ b/objects.js
@@ -5061,7 +5061,7 @@ var u2Mutations = {
         document.getElementById('mutTreeWrapper').innerHTML = '';
         var costText = (Object.keys(this.tree).length > this.purchaseCount) ? "Next Mutator Costs: " + prettify(this.nextCost()) : "All Mutators Purchased!";
         var curTransform = (this.curTransform) ? " style='transform: " + this.curTransform + ";'" : "";
-        var text = "<hr class='visually-hidden' title='top of tooltip'/><div style='position: relative; z-index:2;'><div id='mutMenu' aria-owns='masteryInfo' style='position: absolute; top: 2%; left: 2%; display: inline-block;'><span aria-hidden=true style='font-size: 1.1em; margin-left: 0.25em;' class='btn btn-lg btn-info' onclick='u2Mutations.showNames()' id='u2MutShowNameBtn'>" + ((game.global.showU2MutNames) ? "Hide Names" : "Show Names") + "</span><br/><span tabindex=0 role=button style='font-size: 1.1em; margin-top: 0.25em;' id='swapToMasteryBtn' class='btn btn-lg btn-success' onclick='u2Mutations.swapTab(false)'>Show Masteries" + this.getMasteryAlert() + "</span></div><div style='background-color: black'>Seeds Available: " + prettify(game.global.mutatedSeeds) + "&nbsp;&nbsp;&nbsp;|&nbsp;&nbsp;&nbsp;" + costText + "</div><span role=button tabindex=0 aria-label='close' id='mutTreeCloseBtn' class='icomoon icon-close' onclick='u2Mutations.closeTree()'></span></div><div id='mutTree'" + curTransform + ">";
+        var text = "<hr class='visually-hidden' title='top of tooltip'/><div style='position: relative; z-index:2;'><div id='mutMenu' aria-owns='masteryInfo' style='position: absolute; top: 2%; left: 2%; display: inline-block;'><span aria-hidden=true style='font-size: 1.1em; margin-left: 0.25em;' class='btn btn-lg btn-info' onclick='u2Mutations.showNames()' id='u2MutShowNameBtn'>" + ((game.global.showU2MutNames) ? "Hide Names" : "Show Names") + "</span><br/><span tabindex=0 role=button style='font-size: 1.1em; margin-top: 0.25em;' id='swapToMasteryBtn' class='btn btn-lg btn-success' onclick='u2Mutations.swapTab(false)'>Show Masteries" + this.getMasteryAlert() + "</span></div><div id='mutSeedCounter' style='background-color: black'>Seeds Available: " + prettify(game.global.mutatedSeeds) + "&nbsp;&nbsp;&nbsp;|&nbsp;&nbsp;&nbsp;" + costText + "</div><span role=button tabindex=0 aria-label='close' id='mutTreeCloseBtn' class='icomoon icon-close' onclick='u2Mutations.closeTree()'></span></div><div id='mutTree'" + curTransform + ">";
         text += "<div id='mutRing1' style='width: " + (40.8*scale) + "px; height: " + (33.0*scale) + "px; top: " + (-16.5*scale) + "px; left: " + (-20.4*scale) + "px;'></div>"
 		const headers = {Scruffy: "Scruffy and Heirlooms", Health: "Combat, Radon, and Imports", MaZ: "Resources", Overkill1: "Speed"}
         for (var item in this.tree){
@@ -5190,7 +5190,19 @@ var u2Mutations = {
             var radonReward = rewardResource("helium", 1, 99, false, radonPct);
             message("You were able to take " + prettify(radonReward) + " Radon Vials from that Mutated Enemy!", "Loot", heliumIcon(true), 'helium', 'helium');
         }
-        if (this.open) this.openTree();
+
+        if (this.open) {
+            const nextCost = this.nextCost();
+            if (game.global.mutatedSeeds >= nextCost) {
+                this.openTree();
+            } else {
+                const seedElem = document.getElementById('mutSeedCounter');
+                const costText = Object.keys(this.tree).length > this.purchaseCount ? 'Next Mutator Costs: ' + prettify(nextCost) : 'All Mutators Purchased!';
+                const seedText = `Seeds Available: ${prettify(game.global.mutatedSeeds)}&nbsp;&nbsp;&nbsp;|&nbsp;&nbsp;&nbsp;${costText}`;
+                if (seedElem.innerHTML !== seedText) seedElem.innerHTML = seedText;
+            }
+        }
+		
         this.setAlert();
     },
     addMutations: function(array){

--- a/updates.js
+++ b/updates.js
@@ -650,7 +650,7 @@ function tooltip(what, isItIn, event, textString, attachFunction, numCheck, rena
 		}
 	}
 	if (what == "Rename Preset"){
-		what == "Rename Preset " + selectedPreset;
+		what = "Rename Preset " + selectedPreset;
 		var presetGroup = (portalUniverse == 2) ? game.global.perkPresetU2 : game.global.perkPresetU1;
 		tooltipText = "Type a name below for your Perk Preset! This name will show up on the Preset bar and make it easy to identify which Preset is which."
 		if (textString) tooltipText += " <b>Max of 1,000 for most perks</b>";
@@ -2833,7 +2833,7 @@ function getBattleStatBd(what) {
 		PerkStrength = prettify(PerkStrength * 100) + "%";
 		textString += "<tr><td class='bdTitle'>" + perk.replace('_', ' ') + "</td><td>" + (game.portal[perk].modifier * 100) + "%</td><td>" + prettify(getPerkLevel(perk)) + "</td><td>+ " + PerkStrength + "</td><td class='bdNumberSm'>" + prettify(currentCalc) + "</td>" + ((what == "attack") ? getFluctuation(currentCalc, minFluct, maxFluct) : "") + "</tr>";
 	}
-	if (what == "attack" && getPerkLevel("Tenacity")){
+	if (what == "attack" && (getPerkLevel("Tenacity") || getPerkLevel("Masterfulness"))){
 		amt = game.portal.Tenacity.getMult();
 		currentCalc *= amt;
 		var mins = Math.floor(game.portal.Tenacity.getTime());
@@ -3754,7 +3754,7 @@ function getLootBd(what) {
 		currentCalc *= amt;
 		textString += "<tr><td class='bdTitle'>Looting II (perk)</td><td>+ " + prettify(game.portal.Looting_II.modifier * 100) + "%</td><td>" + prettify(getPerkLevel("Looting_II")) + "</td><td>+ " + prettify((amt - 1) * 100) + "%</td><td>" + prettify(currentCalc) + "</td></tr>";
 	}
-	if (getPerkLevel("Greed")){
+	if (getPerkLevel("Greed") || getPerkLevel("Masterfulness")){
 		amt = game.portal.Greed.getMult();
 		currentCalc *= amt;
 		textString += "<tr><td class='bdTitle'>Greed (perk)</td><td>x" + " " + prettify(game.portal.Greed.getBonusAmt()) + "</td><td>" + (getPerkLevel("Greed") + getPerkLevel("Masterfulness")) + "</td><td>+ " + prettify((amt - 1) * 100) + "%</td><td>" + prettify(currentCalc) + "</td></tr>";


### PR DESCRIPTION
Add extra checks to ensure Tenacity can't go below its minimum multiplier.

Reduce u2Mutations.openTree calls when getting seeds, now only gets called when you can afford a new mutator otherwise it just updates the seeds available element.

Fix the Greed bonus not being applied if Masterfulness has levels and Greed doesn't.
Fix Tenacity not being displayed in the damage breakdown if Masterfulness has levels and Tenacity doesn't.
Fix Rename Preset tooltip not being affixed with the preset number.
Fix Berserk death not occurring when using Map at Spire setting instead of MAZ.