### PR TITLE
fix dire (unreachable?) bug in void map dropping logic

### DIFF
--- a/main.js
+++ b/main.js
@@ -6620,10 +6620,10 @@ function checkVoidMap() {
 	if (game.global.universe == 2 && game.global.totalRadPortals < 1) return;
 	var max = getVoidMaxLevel();
 	if (getLastPortal() != -1){
-			if (max < game.global.world){
+			if (max < game.global.world){ // this check will always return false; upon reaching new HZE, the game calls setVoidMaxLevel with game.global.world, so max **has** to be greater or equal to game.global.world.
 				setVoidMaxLevel(game.global.world);
 				if ((getLastPortal() + 25) < game.global.world)
-					setVoidMaxLevel(getHighestLevelCleared(false, true));
+					setVoidMaxLevel(getHighestLevelCleared(true, true));
 			}
 		if ((max - getLastPortal()) < 25) {
 			max = getLastPortal();


### PR DESCRIPTION
The bug is as follows: currently, there can be a universe crossover where if you push 25 zones past your highest ever zone, it would use your u1 highest-ever-zone for the purposes of the slowdown of void maps due to progress, _**no matter which universe you are currently in.**_

There is another potential bug where this whole check is actually unreachable. i think. close examination of this entire if-block is probably reasonable. The extra indentation may be evidence that it was already somewhat discounted?

Even if it could be reached, this is a very unusual behaviour before u2z200 (where whether the game does this or not, it ceases to matter at all). Usually, pushing to a new hze is a very difficult matter, and highly encouraged to be chipped away at, at basically all points, due to the SA item contracts and scruffy's third ability and all.