### PR TITLE
hotfix proposal: properly multiply c2 and c3 together.

### DIFF
--- a/main.js
+++ b/main.js
@@ -1587,10 +1587,10 @@ function countChallengeSquaredReward(numberOnly, mesmerPreview, getUniverseArray
 	}
 	if (reward > 60000) reward = 60000;
 	if (getUniverseArray) return [reward, rewardU2];
-	reward *= ((rewardU2 / 100) + 1);
-	if (reward >= 2000 && !mesmerPreview) giveSingleAchieve("Challenged");
-	if (numberOnly) return reward;
-	game.global.totalSquaredReward = reward;
+	var totalreward = ((reward / 100) + 1) * ((rewardU2 / 100) + 1) * 100 - 100;
+	if (totalreward >= 2000 && !mesmerPreview) giveSingleAchieve("Challenged");
+	if (numberOnly) return totalreward;
+	game.global.totalSquaredReward = totalreward;
 }
 
 var squaredConfig = {


### PR DESCRIPTION
Following a [discussion in the discord](https://discord.com/channels/371177798305447938/641131706048577536/1357014371175235925), it seems that cinf bonus is not being correctly multiplied together. It is especially apparent at lower numbers. and c3 doesn't apply any bonus at all a c2 = 0; 

due to calculating the c2 and c3 bonuses different in the cinf math, the c2 bonus is off by a factor of +100.

This is a suggested fix, to make it clear how the math actually should work if c2 and c3 are meant to multiply. Assuming totalward = 0 means 'add nothing to multiplier' and not 'multiply by 0'.

Images to show the disparity at low and high numbers

![image](https://github.com/user-attachments/assets/6ed431f9-bed1-4787-81a0-efc82895fae4)
![image](https://github.com/user-attachments/assets/3e551302-b782-4b4d-9f7c-56f132a59703)
(should be -100), +1500% = x16