### PR TITLE
Fix 1px map icon shift upon map selection

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -5058,10 +5058,10 @@ input::-webkit-inner-spin-button {
 }
 
 .mapElementSelected {
-	-webkit-box-shadow:inset 0px 0px 0px 0.2vw #7D2A2A;
-    -moz-box-shadow:inset 0px 0px 0px 0.2vw #7D2A2A;
-    box-shadow:inset 0px 0px 0px 0.2vw #7D2A2A;
-	border: 0;
+	-webkit-box-shadow:inset 0px 0px 0px calc(0.2vw - 1px) #7D2A2A;
+    -moz-box-shadow:inset 0px 0px 0px calc(0.2vw - 1px) #7D2A2A;
+    box-shadow:inset 0px 0px 0px calc(0.2vw - 1px) #7D2A2A;
+	border: 1px solid #7D2A2A;
 }
 
 .mapElementNotSelected {


### PR DESCRIPTION
Before (leaf icon moves 1px to the left upon selection):
![before](https://github.com/user-attachments/assets/0fdca88f-3892-43c1-a8f2-d259eb35d517)

After:
![after](https://github.com/user-attachments/assets/3d66b6fc-e735-4e6c-adb3-d69b94092ce2)
